### PR TITLE
Add tests to guarantee sorted battle commands by constructor

### DIFF
--- a/spec/Entity/Monster/monster_spec.rb
+++ b/spec/Entity/Monster/monster_spec.rb
@@ -32,7 +32,10 @@ RSpec.describe Monster do
                                   helmet: Helmet.new(
                                       stat_change: StatChange.new(
                                               attack: 1, defense: 5)) },
-                        battle_commands: [Attack.new(name: "Kick")],
+                        battle_commands: [
+                          Attack.new(name: "Scratch"),
+                          Attack.new(name: "Kick")
+                        ],
                         escaped: true,
                         message: "\"Oh, hi.\"")
       expect(clown.name).to eq "Clown"
@@ -44,7 +47,11 @@ RSpec.describe Monster do
       expect(clown.gold).to eq 10
       expect(clown.outfit[:weapon]).to eq Weapon.new
       expect(clown.outfit[:helmet]).to eq Helmet.new
-      expect(clown.battle_commands).to eq [Attack.new, Attack.new(name: "Kick")]
+      expect(clown.battle_commands).to eq [
+        Attack.new,
+        Attack.new(name: "Kick"),
+        Attack.new(name: "Scratch")
+      ]
       # cannot be overwritten.
       expect(clown.escaped).to eq false
       expect(clown.message).to eq "\"Oh, hi.\""

--- a/spec/Entity/entity_spec.rb
+++ b/spec/Entity/entity_spec.rb
@@ -34,7 +34,10 @@ RSpec.describe Entity do
                                   helmet: Helmet.new(
                                       stat_change: StatChange.new(
                                               attack: 1, defense: 5)) },
-                        battle_commands: [Attack.new(name: "Kick")],
+                        battle_commands: [
+                          Attack.new(name: "Punch"),
+                          Attack.new(name: "Kick")
+                        ],
                         escaped: true)
       expect(hero.name).to eq "Hero"
       expect(hero.max_hp).to eq 50
@@ -47,7 +50,11 @@ RSpec.describe Entity do
       expect(hero.outfit[:weapon]).to eq Weapon.new
       expect(hero.outfit[:helmet]).to eq Helmet.new
       # Attack.new is present due to the equipped weapon.
-      expect(hero.battle_commands).to eq [Attack.new, Attack.new(name: "Kick")]
+      expect(hero.battle_commands).to eq [
+        Attack.new,
+        Attack.new(name: "Kick"),
+        Attack.new(name: "Punch")
+      ]
       # cannot be overwritten.
       expect(hero.escaped).to eq false
     end

--- a/spec/Entity/player_spec.rb
+++ b/spec/Entity/player_spec.rb
@@ -48,7 +48,10 @@ RSpec.describe Player do
                                   helmet: Helmet.new(
                                       stat_change: StatChange.new(
                                               attack: 1, defense: 5)) },
-                        battle_commands: [BattleCommand.new(name: "Yell")],
+                        battle_commands: [
+                          BattleCommand.new(name: "Yell"),
+                          BattleCommand.new(name: "Run")
+                        ],
                         escaped: true,
                         map: @map,
                         location: Couple.new(1,1))
@@ -61,7 +64,11 @@ RSpec.describe Player do
       expect(hero.gold).to eq 10
       expect(hero.outfit[:weapon]).to eq Weapon.new
       expect(hero.outfit[:helmet]).to eq Helmet.new
-      expect(hero.battle_commands).to eq [Attack.new, BattleCommand.new(name: "Yell")]
+      expect(hero.battle_commands).to eq [
+        Attack.new,
+        BattleCommand.new(name: "Run"),
+        BattleCommand.new(name: "Yell")
+      ]
       # cannot be overwritten.
       expect(hero.escaped).to eq false
       expect(hero.map).to eq @map


### PR DESCRIPTION
Fixes https://github.com/nskins/goby/issues/19

Just added some tests ensuring battle commands passed to entity constructors gets sorted after the object is created.

Submitted during of our [KW Ruby meetup](https://www.meetup.com/kw-ruby-on-rails/events/234273702/) in Canada 🤘 
