### PR TITLE
Use keyword arguments for default parameters

### DIFF
--- a/lib/Battle/BattleCommand/Attack/attack.rb
+++ b/lib/Battle/BattleCommand/Attack/attack.rb
@@ -2,17 +2,20 @@ require_relative '../battle_command.rb'
 
 class Attack < BattleCommand
 
-  # @param [Hash] params the parameters for creating an Attack.
-  # @option params [String] :name the name.
-  # @option params [Integer] :strength the strength.
-  # @option params [Integer] :success_rate the chance of success.
-  def initialize(params = {})
-    super(params)
-    @name = params[:name] || "Attack"
-    @strength = params[:strength] || 0
-    @success_rate = params[:success_rate] || 100
-    @description = params[:description] || "    Strength: #{@strength}\n"\
-                                           "    Success Rate: #{@success_rate}%\n"
+  # @param [String] name the name.
+  # @param [Integer] strength the strength.
+  # @param [Integer] success_rate the chance of success.
+  # @param [String] description a summary/message of its purpose.
+  def initialize(name: "Attack", strength: 0, success_rate: 100, description: nil)
+    super(name: name, description: description)
+    
+    @strength = strength
+    @success_rate = success_rate
+    
+    if description.nil?
+      @description = "    Strength: #{@strength}\n"\
+                     "    Success Rate: #{@success_rate}%\n"
+    end
 
   end
 

--- a/lib/Battle/BattleCommand/Attack/kick.rb
+++ b/lib/Battle/BattleCommand/Attack/kick.rb
@@ -2,11 +2,8 @@ require_relative 'attack.rb'
 
 # PRESET DATA
 class Kick < Attack
-  def initialize(params = { name: "Kick",
-                            strength: 5,
-                            success_rate: 99} )
-    super(params)
+  def initialize
+    super(name: "Kick", strength: 5, success_rate: 99)
   end
-
 end
 

--- a/lib/Battle/BattleCommand/Attack/smash.rb
+++ b/lib/Battle/BattleCommand/Attack/smash.rb
@@ -2,11 +2,7 @@ require_relative 'attack.rb'
 
 # PRESET DATA
 class Smash < Attack
-
-  def initialize(params = { name: "Smash",
-                            strength: 10,
-                            success_rate: 80 } )
-    super(params)
+  def initialize
+    super(name: "Smash", strength: 10, success_rate: 80)
   end
-
 end

--- a/lib/Battle/BattleCommand/battle_command.rb
+++ b/lib/Battle/BattleCommand/battle_command.rb
@@ -1,11 +1,10 @@
 class BattleCommand
 
-  # @param [Hash] params the parameters for creating a BattleCommand.
-  # @option params [String] :name the name.
-  # @option params [String] :description a summary/message of its purpose.
-  def initialize(params = {})
-    @name = params[:name] || "BattleCommand"
-    @description = params[:description]
+  # @param [String] name the name.
+  # @param [String] description a summary/message of its purpose.
+  def initialize(name: "BattleCommand", description: nil)
+    @name = name
+    @description = description
   end
 
   # The process that runs when this command is used in battle.

--- a/lib/Battle/BattleCommand/escape.rb
+++ b/lib/Battle/BattleCommand/escape.rb
@@ -2,10 +2,8 @@ require_relative 'battle_command.rb'
 
 # PRESET DATA
 class Escape < BattleCommand
-  def initialize(params = {})
-    super(params)
-    @name = "Escape"
-    @description = "    Attempt to flee from the enemy.\n"
+  def initialize
+    super(name: "Escape", description: "    Attempt to flee from the enemy.\n")
   end
 
   # Samples a probability to determine if the user will escape from battle.

--- a/lib/Entity/Monster/alien.rb
+++ b/lib/Entity/Monster/alien.rb
@@ -3,15 +3,8 @@ require_relative '../../Battle/BattleCommand/Attack/kick.rb'
 
 # PRESET DATA
 class Alien < Monster
-  def initialize(params = {})
-    super(params)
-    @name = "Alien"
-    @max_hp = @hp = 30
-    @attack = 6
-    @defense = 2
-    @agility = 2
-    @battle_commands = [ Kick.new ]
-    @gold = 20
-    @message = "\"I come from another world.\""
+  def initialize
+    super(name: "Alien", max_hp: 30, attack: 6, defense: 2, agility: 2, 
+          battle_commands: [Kick.new], gold: 20, message: "\"I come from another world.\"")
   end
 end

--- a/lib/Entity/Monster/monster.rb
+++ b/lib/Entity/Monster/monster.rb
@@ -2,21 +2,22 @@ require_relative "../entity.rb"
 
 class Monster < Entity
 
-	# @param [Hash] params the parameters for creating a Monster.
-  # @option params [String] :name the name.
-  # @option params [Integer] :max_hp the greatest amount of health.
-  # @option params [Integer] :hp the current amount of health.
-  # @option params [Integer] :attack the strength in battle.
-  # @option params [Integer] :defense the prevention of attack power on oneself.
-  # @option params [[Couple(Item, Integer)]] :inventory a list of pairs of items and their respective amounts.
-  # @option params [Integer] :gold the max amount of gold that can be rewarded to the opponent.
-  # @option params [[BattleCommand]] :battle_commands the commands that can be used in battle.
-  # @option params [Hash] :outfit the collection of equippable items currently worn.
-	# @option params [String] :message the monster's battle cry.
-	def initialize(params = {})
-		super(params)
-		@name = params[:name] || "Monster"
-		@message = params[:message] || "!!!"
+  # @param [String] name the name.
+  # @param [Integer] max_hp the greatest amount of health.
+  # @param [Integer] hp the current amount of health.
+  # @param [Integer] attack the strength in battle.
+  # @param [Integer] defense the prevention of attack power on oneself.
+	# @param [Integer] agility the speed in battle.
+  # @param [[Couple(Item, Integer)]] inventory a list of pairs of items and their respective amounts.
+  # @param [Integer] gold the max amount of gold that can be rewarded to the opponent.
+  # @param [[BattleCommand]] battle_commands the commands that can be used in battle.
+  # @param [Hash] outfit the collection of equippable items currently worn.
+	# @param [String] message the monster's battle cry.
+	def initialize(name: "Monster", max_hp: 1, hp: nil, attack: 1, defense: 1, agility: 1, 
+								 inventory: [], gold: 0, battle_commands: [], outfit: {}, message: "!!!")
+		super(name: name, max_hp: max_hp, hp: hp, attack: attack, defense: defense, agility: agility,
+					inventory: inventory, gold: gold, battle_commands: battle_commands, outfit: outfit)
+		@message = message
 	end
 
 	attr_accessor :message

--- a/lib/Entity/entity.rb
+++ b/lib/Entity/entity.rb
@@ -2,39 +2,42 @@ require_relative '../util.rb'
 
 class Entity
 
-  # @param [Hash] params the parameters for creating an Entity.
-  # @option params [String] :name the name.
-  # @option params [Integer] :max_hp the greatest amount of health.
-  # @option params [Integer] :hp the current amount of health.
-  # @option params [Integer] :attack the strength in battle.
-  # @option params [Integer] :defense the prevention of attack power on oneself.
-  # @option params [[Couple(Item, Integer)]] :inventory a list of pairs of items and their respective amounts.
-  # @option params [Integer] :gold the currency used for economical transactions.
-  # @option params [[BattleCommand]] :battle_commands the commands that can be used in battle.
-  # @option params [Hash] :outfit the collection of equippable items currently worn.
-  def initialize(params = {})
-    @name = params[:name] || "Entity"
-
-    @max_hp = hp = params[:max_hp] || 1
-    @hp = params[:hp] || hp
-    @attack = params[:attack] || 1
-    @defense = params[:defense] || 1
-    @agility = params[:agility] || 1
-
-    @inventory = params[:inventory] || Array.new
-    @gold = params[:gold] || 0
-
-    @battle_commands = params[:battle_commands] || Array.new
+  # @param [String] name the name.
+  # @param [Integer] max_hp the greatest amount of health.
+  # @param [Integer] hp the current amount of health.
+  # @param [Integer] attack the strength in battle.
+  # @param [Integer] defense the prevention of attack power on oneself.
+  # @param [Integer] agility the speed in battle.
+  # @param [[Couple(Item, Integer)]] inventory a list of pairs of items and their respective amounts.
+  # @param [Integer] gold the currency used for economical transactions.
+  # @param [[BattleCommand]] battle_commands the commands that can be used in battle.
+  # @param [Hash] outfit the collection of equippable items currently worn.
+  def initialize(name: "Entity", max_hp: 1, hp: nil, attack: 1, defense: 1, agility: 1,
+                 inventory: [], gold: 0, battle_commands: [], outfit: {})
+    @name = name
+    @max_hp = max_hp
+    
+    if hp.nil?
+      @hp = @max_hp
+    else
+      @hp = hp
+    end
+    (@max_hp = @hp) if (@hp > @max_hp)
+    
+    @attack = attack
+    @defense = defense
+    @agility = agility
+    @inventory = inventory
+    @gold = gold
+    
+    @battle_commands = battle_commands
     # Maintain sorted battle commands.
     @battle_commands.sort!{ |x,y| x.name <=> y.name }
 
     # See its attr_accessor below.
-    @outfit = Hash.new
-    if params[:outfit]
-      params[:outfit].each do |type,value|
-        value.equip(self)
-      end
-      @outfit = params[:outfit]
+    @outfit = {}
+    outfit.each do |type,value|
+      value.equip(self)
     end
 
     # This should only be switched to true during battle.

--- a/lib/Entity/player.rb
+++ b/lib/Entity/player.rb
@@ -8,33 +8,35 @@ class Player < Entity
   DEFAULT_MAP = Map.new(tiles: [ [Tile.new] ])
   DEFAULT_LOCATION = Couple.new(0,0)
 
-  # @param [Hash] params the parameters for creating a Player.
-  # @option params [String] :name the name.
-  # @option params [Integer] :max_hp the greatest amount of health.
-  # @option params [Integer] :hp the current amount of health.
-  # @option params [Integer] :attack the strength in battle.
-  # @option params [Integer] :defense the prevention of attack power on oneself.
-  # @option params [[Couple(Item, Integer)]] :inventory a list of pairs of items and their respective amounts.
-  # @option params [Integer] :gold the currency used for economical transactions.
-  # @option params [[BattleCommand]] :battle_commands the commands that can be used in battle.
-  # @option params [Hash] :outfit the collection of equippable items currently worn.
-  # @option params [Map] :map the map on which the player is located.
-  # @option params [Couple(Integer,Integer)] :location the 2D index of the map (the exact tile).
-  def initialize(params = {})
-    super(params)
-    @name = params[:name] || "Player"
+  # @param [String] name the name.
+  # @param [Integer] max_hp the greatest amount of health.
+  # @param [Integer] hp the current amount of health.
+  # @param [Integer] attack the strength in battle.
+  # @param [Integer] defense the prevention of attack power on oneself.
+  # @param [Integer] agility the speed in battle.
+  # @param [[Couple(Item, Integer)]] inventory a list of pairs of items and their respective amounts.
+  # @param [Integer] gold the currency used for economical transactions.
+  # @param [[BattleCommand]] battle_commands the commands that can be used in battle.
+  # @param [Hash] outfit the collection of equippable items currently worn.
+  # @param [Map] map the map on which the player is located.
+  # @param [Couple(Integer,Integer)] location the 2D index of the map (the exact tile).
+  def initialize(name: "Player", max_hp: 1, hp: nil, attack: 1, defense: 1, agility: 1,
+                 inventory: [], gold: 0, battle_commands: [], outfit: {}, map: DEFAULT_MAP,
+                 location: DEFAULT_LOCATION)
+    super(name: name, max_hp: max_hp, hp: hp, attack: attack, defense: defense, agility: agility,
+          inventory: inventory, gold: gold, battle_commands: battle_commands, outfit: outfit)
 
     @map = DEFAULT_MAP
     @location = DEFAULT_LOCATION
 
     # Ensure that the map and the location are valid.
-    if (params[:map] && params[:location])
+    if (map && location)
 
-      y = params[:location].first; x = params[:location].second
+      y = location.first; x = location.second
 
-      if (params[:map].in_bounds(y,x) && params[:map].tiles[y][x].passable)
-        @map = params[:map]
-        @location = params[:location]
+      if (map.in_bounds(y,x) && map.tiles[y][x].passable)
+        @map = map
+        @location = location
       end
     end
 

--- a/lib/Event/NPC/dan.rb
+++ b/lib/Event/NPC/dan.rb
@@ -4,8 +4,8 @@ require_relative '../../Item/shovel.rb'
 
 # PRESET DATA
 class Dan < NPC
-  def initialize(params = { name: "Dan" })
-    super(params)
+  def initialize
+    super(name: "Dan")
   end
 
   def run(player)

--- a/lib/Event/NPC/npc.rb
+++ b/lib/Event/NPC/npc.rb
@@ -2,13 +2,12 @@ require_relative '../event.rb'
 
 class NPC < Event
 
-  # @param [Hash] params the parameters for creating a NPC.
-  # @option params [String] :name the name.
-  # @option params [Integer] :mode convenient way for a NPC to have multiple actions.
-  # @option params [Boolean] :visible whether the NPC can be seen/activated.
-  def initialize(params = {})
-    super(params)
-    @name = params[:name] || "NPC"
+  # @param [String] name the name.
+  # @param [Integer] mode convenient way for a NPC to have multiple actions.
+  # @param [Boolean] visible whether the NPC can be seen/activated.
+  def initialize(name: "NPC", mode: 0, visible: true)
+    super(mode: mode, visible: visible)
+    @name = name
     @command = "talk"
   end
 

--- a/lib/Event/Shop/bakery.rb
+++ b/lib/Event/Shop/bakery.rb
@@ -4,12 +4,7 @@ require_relative '../../Item/Equippable/Weapon/baguette.rb'
 
 # PRESET DATA
 class Bakery < Shop
-
-  def initialize(params = {})
-    super(params)
-    @name = "Bob's Bakery"
-    @items = [Donut.new, Baguette.new]
+  def initialize
+    super(name: "Bob's Bakery", items: [Donut.new, Baguette.new])
   end
-
-
 end

--- a/lib/Event/Shop/shop.rb
+++ b/lib/Event/Shop/shop.rb
@@ -1,17 +1,16 @@
 require_relative '../event.rb'
 
 class Shop < Event
-
-  # @param [Hash] params the parameters for creating a Shop.
-  # @option params [String] :name the name.
-  # @option params [Integer] :mode convenient way for a shop to have multiple actions.
-  # @option params [Boolean] :visible whether the shop can be seen/activated.
-  # @option params [[Item]] :items an array of items that the shop sells.
-  def initialize(params = {})
-    super(params)
-    @name = params[:name] || "Shop"
+  
+  # @param [String] name the name.
+  # @param [Integer] mode convenient way for a shop to have multiple actions.
+  # @param [Boolean] visible whether the shop can be seen/activated.
+  # @param [[Item]] items an array of items that the shop sells.
+  def initialize(name: "Shop", mode: 0, visible: true, items: [])
+    super(mode: mode, visible: visible)
+    @name = name
     @command = "shop"
-    @items = params[:items] || Array.new
+    @items = items
   end
 
   # Returns the index of the specified item, if it exists.

--- a/lib/Event/Shop/wacky_clothes.rb
+++ b/lib/Event/Shop/wacky_clothes.rb
@@ -5,9 +5,8 @@ require_relative '../../Item/Equippable/Shield/riot_shield.rb'
 require_relative '../../Item/Equippable/Torso/parka.rb'
 
 class WackyClothesShop < Shop
-  def initialize(params = { name: "the Wacky Clothes Shop",
-                            items: [ Bucket.new, RippedPants.new,
-                                     Parka.new, RiotShield.new ] })
-    super(params)
+  def initialize
+    super(name: "the Wacky Clothes Shop", items: [Bucket.new, RippedPants.new, 
+                                                  Parka.new, RiotShield.new])
   end
 end

--- a/lib/Event/box.rb
+++ b/lib/Event/box.rb
@@ -3,10 +3,9 @@ require_relative 'event.rb'
 # PRESET DATA
 class Box < Event
 
-  def initialize(params = {})
-    super(params)
-    @command = "open"
-    @gold = params[:gold] || 0
+  def initialize(gold: 0)
+    super(command: "open")
+    @gold = gold
   end
 
   def run(player)

--- a/lib/Event/event.rb
+++ b/lib/Event/event.rb
@@ -1,18 +1,17 @@
 class Event
 
-  # @param [Hash] params the parameters for creating an Event.
-  # @option params [String] :command the command to activate the event.
-  # @option params [Integer] :mode convenient way for an event to have multiple actions.
-  # @option params [Boolean] :visible whether the event can be seen/activated.
-  def initialize(params = {})
-    @command = params[:command] || "event"
-
+  # @param [String] command the command to activate the event.
+  # @param [Integer] mode convenient way for an event to have multiple actions.
+  # @param [Boolean] visible whether the event can be seen/activated.
+  def initialize(command: "event", mode: 0, visible: true)
+    @command = command
+    
     # Can be used in a case statement in run for different outcomes.
-    @mode = params[:mode] || 0
+    @mode = mode
 
     # The event can only be activated when this is true.
-    if params[:visible].nil? then @visible = true
-    else @visible = params[:visible] end
+    @visible = visible
+    
   end
 
   # The function that runs when the player activates the event.
@@ -29,8 +28,6 @@ class Event
   end
 
   # Specify the command in the subclass.
-  attr_accessor :command
-  attr_accessor :mode
-  attr_accessor :visible
+  attr_accessor :command, :mode, :visible
 
 end

--- a/lib/Event/hole.rb
+++ b/lib/Event/hole.rb
@@ -2,10 +2,9 @@ require_relative 'event.rb'
 
 # PRESET DATA
 class Hole < Event
-  def initialize(params = {command: "dig",
-                           max_reward: 20})
-    super(params)
-    @max_reward = params[max_reward] || 20
+  def initialize(max_reward: 20)
+    super(command: "dig")
+    @max_reward = max_reward
     (@max_reward = 1) if (@max_reward < 1)
   end
 

--- a/lib/Item/Equippable/Helmet/bucket.rb
+++ b/lib/Item/Equippable/Helmet/bucket.rb
@@ -2,9 +2,7 @@ require_relative 'helmet.rb'
 
 # PRESET DATA
 class Bucket < Helmet
-  def initialize(params = { name: "Bucket",
-                            price: 20,
-                            stat_change: {defense: 2}})
-    super(params)
+  def initialize
+    super(name: "Bucket", price: 20, stat_change: {defense: 2})
   end
 end

--- a/lib/Item/Equippable/Helmet/helmet.rb
+++ b/lib/Item/Equippable/Helmet/helmet.rb
@@ -2,14 +2,12 @@ require_relative '../equippable.rb'
 
 class Helmet < Equippable
 
-  # @param [Hash] params the parameters for creating a Helmet.
-  # @option params [String] :name the name.
-  # @option params [Integer] :price the cost in a shop.
-  # @option params [Boolean] :consumable determines whether the item is lost when used.
-  # @option params [Hash] :stat_change the change in stats for when the item is equipped.
-  def initialize(params = {})
-    super(params)
-    @name = params[:name] || "Helmet"
+  # @param [String] name the name.
+  # @param [Integer] price the cost in a shop.
+  # @param [Boolean] consumable upon use, the item is lost when true.
+  # @param [Hash] stat_change the change in stats for when the item is equipped.
+  def initialize(name: "Helmet", price: 0, consumable: false, stat_change: {})
+    super(name: name, price: price, consumable: consumable, stat_change: stat_change)
     @type = :helmet
   end
 

--- a/lib/Item/Equippable/Legs/legs.rb
+++ b/lib/Item/Equippable/Legs/legs.rb
@@ -2,14 +2,12 @@ require_relative '../equippable.rb'
 
 class Legs < Equippable
 
-  # @param [Hash] params the parameters for creating Legs.
-  # @option params [String] :name the name.
-  # @option params [Integer] :price the cost in a shop.
-  # @option params [Boolean] :consumable determines whether the item is lost when used.
-  # @option params [Hash] :stat_change the change in stats for when the item is equipped.
-  def initialize(params = {})
-    super(params)
-    @name = params[:name] || "Legs"
+  # @param [String] name the name.
+  # @param [Integer] price the cost in a shop.
+  # @param [Boolean] consumable upon use, the item is lost when true.
+  # @param [Hash] stat_change the change in stats for when the item is equipped.
+  def initialize(name: "Legs", price: 0, consumable: false, stat_change: {})
+    super(name: name, price: price, consumable: consumable, stat_change: stat_change)
     @type = :legs
   end
 

--- a/lib/Item/Equippable/Legs/ripped_pants.rb
+++ b/lib/Item/Equippable/Legs/ripped_pants.rb
@@ -2,9 +2,7 @@ require_relative 'legs.rb'
 
 # PRESET DATA
 class RippedPants < Legs
-  def initialize(params = { name: "Ripped Pants",
-                            price: 25,
-                            stat_change: {defense: 3}})
-    super(params)
+  def initialize
+    super(name: "Ripped Pants", price: 25, stat_change: {defense: 3})
   end
 end

--- a/lib/Item/Equippable/Shield/riot_shield.rb
+++ b/lib/Item/Equippable/Shield/riot_shield.rb
@@ -2,9 +2,7 @@ require_relative 'shield.rb'
 
 # PRESET DATA
 class RiotShield < Shield
-  def initialize(params = { name: "Riot Shield",
-                            price: 75,
-                            stat_change: {defense: 8}})
-    super(params)
+  def initialize
+    super(name: "Riot Shield", price: 75, stat_change: {defense: 8})
   end
 end

--- a/lib/Item/Equippable/Shield/shield.rb
+++ b/lib/Item/Equippable/Shield/shield.rb
@@ -2,14 +2,12 @@ require_relative '../equippable.rb'
 
 class Shield < Equippable
 
-  # @param [Hash] params the parameters for creating a Shield.
-  # @option params [String] :name the name.
-  # @option params [Integer] :price the cost in a shop.
-  # @option params [Boolean] :consumable determines whether the item is lost when used.
-  # @option params [Hash] :stat_change the change in stats for when the item is equipped.
-  def initialize(params = {})
-    super(params)
-    @name = params[:name] || "Shield"
+  # @param [String] name the name.
+  # @param [Integer] price the cost in a shop.
+  # @param [Boolean] consumable upon use, the item is lost when true.
+  # @param [Hash] stat_change the change in stats for when the item is equipped.
+  def initialize(name: "Shield", price: 0, consumable: false, stat_change: {})
+    super(name: name, price: price, consumable: consumable, stat_change: stat_change)
     @type = :shield
   end
 

--- a/lib/Item/Equippable/Torso/parka.rb
+++ b/lib/Item/Equippable/Torso/parka.rb
@@ -2,9 +2,7 @@ require_relative 'torso.rb'
 
 # PRESET DATA
 class Parka < Torso
-  def initialize(params = { name: "Parka",
-                            price: 40,
-                            stat_change: {defense: 4}})
-    super(params)
+  def initialize
+    super(name: "Parka", price: 40, stat_change: {defense: 4})
   end
 end

--- a/lib/Item/Equippable/Torso/torso.rb
+++ b/lib/Item/Equippable/Torso/torso.rb
@@ -2,14 +2,12 @@ require_relative '../equippable.rb'
 
 class Torso < Equippable
 
-  # @param [Hash] params the parameters for creating a Torso.
-  # @option params [String] :name the name.
-  # @option params [Integer] :price the cost in a shop.
-  # @option params [Boolean] :consumable determines whether the item is lost when used.
-  # @option params [Hash] :stat_change the change in stats for when the item is equipped.
-  def initialize(params = {})
-    super(params)
-    @name = params[:name] || "Torso"
+  # @param [String] name the name.
+  # @param [Integer] price the cost in a shop.
+  # @param [Boolean] consumable determines whether the item is lost when used.
+  # @param [Hash] stat_change the change in stats for when the item is equipped.
+  def initialize(name: "Torso", price: 0, consumable: false, stat_change: {})
+    super(name: name, price: price, consumable: consumable, stat_change: stat_change)
     @type = :torso
   end
 

--- a/lib/Item/Equippable/Weapon/baguette.rb
+++ b/lib/Item/Equippable/Weapon/baguette.rb
@@ -3,11 +3,8 @@ require_relative '../../../Battle/BattleCommand/Attack/smash.rb'
 
 # PRESET DATA
 class Baguette < Weapon
-  def initialize(params = {})
-    super(params)
-    @name = "Baguette"
-    @price = 40
-    @stat_change = {attack: 8, defense: 2}
+  def initialize
+    super(name: "Baguette", price: 40, stat_change: {attack: 8, defense: 2})
     @attack = Smash.new
   end
 end

--- a/lib/Item/Equippable/Weapon/weapon.rb
+++ b/lib/Item/Equippable/Weapon/weapon.rb
@@ -3,16 +3,14 @@ require_relative '../../../Battle/BattleCommand/Attack/attack.rb'
 
 class Weapon < Equippable
 
-  # @param [Hash] params the parameters for creating a Weapon.
-  # @option params [String] :name the name.
-  # @option params [Integer] :price the cost in a shop.
-  # @option params [Boolean] :consumable determines whether the item is lost when used.
-  # @option params [Hash] :stat_change the change in stats for when the item is equipped.
-  # @option params [Attack] :attack the attack which is added to the entity's battle commands.
-  def initialize(params = {})
-    super(params)
-    @name = params[:name] || "Weapon"
-    @attack = params[:attack] || nil
+  # @param [String] name the name.
+  # @param [Integer] price the cost in a shop.
+  # @param [Boolean] consumable determines whether the item is lost when used.
+  # @param [Hash] stat_change the change in stats for when the item is equipped.
+  # @param [Attack] attack the attack which is added to the entity's battle commands.
+  def initialize(name: "Weapon", price: 0, consumable: false, stat_change: {}, attack: nil)
+    super(name: name, price: price, consumable: consumable, stat_change: stat_change)
+    @attack = attack
     @type = :weapon
   end
 

--- a/lib/Item/Equippable/equippable.rb
+++ b/lib/Item/Equippable/equippable.rb
@@ -2,20 +2,13 @@ require_relative '../item.rb'
 
 class Equippable < Item
 
-  # @param [Hash] params the parameters for creating an Equippable.
-  # @option params [String] :name the name.
-  # @option params [Integer] :price the cost in a shop.
-  # @option params [Boolean] :consumable determines whether the item is lost when used.
-  # @option params [Hash] :stat_change the change in stats for when the item is equipped.
-  def initialize(params = {})
-    super(params)
-    @name = params[:name] || "Equippable"
-
-    # Equippables are consumed through the entity's equip_item function.
-    if params[:consumable].nil? then @consumable = false
-    else @consumable = params[:consumable] end
-
-    @stat_change = params[:stat_change] || {}
+  # @param [String] name the name.
+  # @param [Integer] price the cost in a shop.
+  # @param [Boolean] consumable upon use, the item is lost when true.
+  # @param [Hash] stat_change the change in stats for when the item is equipped.
+  def initialize(name: "Equippable", price: 0, consumable: false, stat_change: {})
+    super(name: name, price: price, consumable: consumable)
+    @stat_change = stat_change
     @type = :equippable
   end
   

--- a/lib/Item/Food/donut.rb
+++ b/lib/Item/Food/donut.rb
@@ -2,10 +2,7 @@ require_relative 'food.rb'
 
 # PRESET DATA
 class Donut < Food
-  def initialize(params = {})
-    super(params)
-    @name = "Donut"
-    @price = 10
-    @recovers = 15
+  def initialize
+    super(name: "Donut", price: 10, recovers: 15)
   end
 end

--- a/lib/Item/Food/food.rb
+++ b/lib/Item/Food/food.rb
@@ -2,15 +2,13 @@ require_relative '../item.rb'
 
 class Food < Item
 
-  # @param [Hash] params the parameters for creating a Food.
-  # @option params [String] :name the name.
-  # @option params [Integer] :price the cost in a shop.
-  # @option params [Boolean] :consumable determines whether the food is lost when used.
-  # @option params [Integer] :recovers the amount of HP recovered when used.
-  def initialize(params = {})
-    super(params)
-    @name = params[:name] || "Food"
-    @recovers = params[:recovers] || 0
+  # @param [String] name the name.
+  # @param [Integer] price the cost in a shop.
+  # @param [Boolean] consumable upon use, the item is lost when true.
+  # @param [Integer] recovers the amount of HP recovered when used.
+  def initialize(name: "Food", price: 0, consumable: true, recovers: 0)
+    super(name: name, price: price, consumable: consumable)
+    @recovers = recovers
   end
 
   # Heals the entity.

--- a/lib/Item/item.rb
+++ b/lib/Item/item.rb
@@ -1,15 +1,12 @@
 class Item
-
-  # @param [Hash] params the parameters for creating an Item.
-  # @option params [String] :name the name.
-  # @option params [Integer] :price the cost in a shop.
-  # @option params [Boolean] :consumable determines whether the item is lost when used.
-  def initialize(params = {})
-    @name = params[:name] || "Item"
-    @price = params[:price] || 0
-
-    if params[:consumable].nil? then @consumable = true
-    else @consumable = params[:consumable] end
+  
+  # @param [String] name the name.
+  # @param [Integer] price the cost in a shop.
+  # @param [Boolean] consumable upon use, the item is lost when true.
+  def initialize(name: "Item", price: 0, consumable: true)
+    @name = name
+    @price = price
+    @consumable = consumable
   end
 
   # The function that executes when one uses the item.

--- a/lib/Item/shovel.rb
+++ b/lib/Item/shovel.rb
@@ -1,8 +1,8 @@
 require_relative 'item.rb'
 
 class Shovel < Item
-  def initialize(params = { name: "Shovel", consumable: false })
-    super(params)
+  def initialize
+    super(name: "Shovel", consumable: false)
   end
 
   def use(entity)

--- a/lib/Map/Map/donut_field.rb
+++ b/lib/Map/Map/donut_field.rb
@@ -10,14 +10,17 @@ require_relative '../../Event/Shop/wacky_clothes.rb'
 
 # PRESET DATA
 class DonutField < Map
-  def initialize(params = {})
-    @name = "Donut Field"
+  def initialize
+    super(name: "Donut Field")
     
     dirt = Dirt.new
     wall = Wall.new
     
-    shop = Tile.new(graphic: "△")
-    event = Dirt.new(graphic: "?")
+    shop = Tile.new
+    shop.graphic = '△'
+    
+    event = Dirt.new
+    event.graphic = '?'
     
     @tiles = Array.new
     
@@ -52,8 +55,5 @@ class DonutField < Map
     @tiles[2][2] = shop.clone
     @tiles[2][2].description = "There is a shop with strange clothes nearby."
     @tiles[2][2].events = [WackyClothesShop.new]
-
-    # Set the location for the character to spawn after death.
-    @regen_location = Couple.new(0,0)
   end
 end

--- a/lib/Map/Map/map.rb
+++ b/lib/Map/Map/map.rb
@@ -1,13 +1,12 @@
 class Map
 
-	# @param [Hash] params the parameters for creating a Map.
-	# @option params [String] :name the name.
-	# @option params [[Tile]] :tiles the content of the map.
-	# @option params [Couple(Int,Int)] :regen_location the respawn-on-death coordinates.
-	def initialize(params = {})
-		@name = params[:name] || "Map"
-		@tiles = params[:tiles] || [ [Tile.new ] ]
-		@regen_location = params[:regen_location] || Couple.new(0,0)
+	# @param [String] name the name.
+	# @param [[Tile]] tiles the content of the map.
+	# @param [Couple(Int,Int)] regen_location the respawn-on-death coordinates.
+	def initialize(name: "Map", tiles: [[Tile.new]], regen_location: Couple.new(0,0))
+		@name = name
+		@tiles = tiles
+		@regen_location = regen_location
 	end
 
 	# @param [Map] rhs the map on the right.

--- a/lib/Map/Tile/dirt.rb
+++ b/lib/Map/Tile/dirt.rb
@@ -2,8 +2,7 @@ require_relative 'tile.rb'
 
 # PRESET DATA
 class Dirt < Tile
-  def initialize(params = {})
-    super(params)
-    @description = params[:description] || "Dirt surrounds you."
+  def initialize
+    super(description: "Dirt surrounds you.")
   end
 end

--- a/lib/Map/Tile/tile.rb
+++ b/lib/Map/Tile/tile.rb
@@ -5,24 +5,22 @@ class Tile
 	# Default graphic for impassable tiles.
 	DEFAULT_IMPASSABLE = "■"
 
-	# @param [Hash] params the parameters for creating a Tile.
-  # @option params [Boolean] :passable if true, the player can move here.
-	# @option params [Boolean] :seen if true, it will be printed on the map.
-	# @option params [String] :description a summary/message of the contents.
-	# @option params [[Event]] :events the events found on this tile.
-	# @option params [[Monster]] :monsters the monsters found on this tile.
-	# @option params [String] :graphic the representation of the tile graphically.
-	def initialize(params = {})
-		if params[:passable].nil? then @passable = true
-    else @passable = params[:passable] end
-
-		if params[:seen].nil? then @seen = false
-    else @seen = params[:seen] end
-
-		@description = params[:description] || ""
-		@events = params[:events] || Array.new
-		@monsters = params[:monsters] || Array.new
-		@graphic = params[:graphic] || default_graphic
+  # @param [Boolean] passable if true, the player can move here.
+	# @param [Boolean] seen if true, it will be printed on the map.
+	# @param [String] description a summary/message of the contents.
+	# @param [[Event]] events the events found on this tile.
+	# @param [[Monster]] monsters the monsters found on this tile.
+	# @param [String] graphic the representation of the tile graphically.
+	def initialize(passable: true, seen: false, description: "", events: [], monsters: [], graphic: nil)
+		@passable = passable
+		@seen = seen
+		@description = description
+		@events = events
+		@monsters = monsters
+		
+		# Note: better solution in Haskell.
+		if graphic.nil? then @graphic = default_graphic
+		else @graphic = graphic end
 	end
 
 	attr_accessor :passable, :seen, :description, :events, :monsters, :graphic

--- a/lib/Map/Tile/wall.rb
+++ b/lib/Map/Tile/wall.rb
@@ -2,7 +2,7 @@ require_relative 'tile.rb'
 
 # PRESET DATA
 class Wall < Tile
-  def initialize(params = {passable: false})
-    super(params)
+  def initialize
+    super(passable: false)
   end
 end

--- a/spec/Entity/Monster/monster_spec.rb
+++ b/spec/Entity/Monster/monster_spec.rb
@@ -39,7 +39,6 @@ RSpec.describe Monster do
                           Attack.new(name: "Scratch"),
                           Attack.new(name: "Kick")
                         ],
-                        escaped: true,
                         message: "\"Oh, hi.\"")
       expect(clown.name).to eq "Clown"
       expect(clown.max_hp).to eq 20

--- a/spec/Entity/entity_spec.rb
+++ b/spec/Entity/entity_spec.rb
@@ -39,8 +39,7 @@ RSpec.describe Entity do
                         battle_commands: [
                           Attack.new(name: "Punch"),
                           Attack.new(name: "Kick")
-                        ],
-                        escaped: true)
+                        ])
       expect(hero.name).to eq "Hero"
       expect(hero.max_hp).to eq 50
       expect(hero.hp).to eq 35

--- a/spec/Entity/entity_spec.rb
+++ b/spec/Entity/entity_spec.rb
@@ -60,6 +60,23 @@ RSpec.describe Entity do
       # cannot be overwritten.
       expect(hero.escaped).to eq false
     end
+    
+    it "assigns default keyword arguments as appropriate" do
+      entity = Entity.new(max_hp: 7,
+                        defense: 9,
+                        gold: 3)
+      expect(entity.name).to eq "Entity"
+      expect(entity.max_hp).to eq 7
+      expect(entity.hp).to eq 7
+      expect(entity.attack).to eq 1
+      expect(entity.defense).to eq 9
+      expect(entity.agility).to eq 1
+      expect(entity.inventory).to eq []
+      expect(entity.gold).to eq 3
+      expect(entity.battle_commands).to eq []
+      # cannot be overwritten.
+      expect(entity.escaped).to eq false
+    end
   end
 
   context "add battle command" do

--- a/spec/Entity/player_spec.rb
+++ b/spec/Entity/player_spec.rb
@@ -52,7 +52,6 @@ RSpec.describe Player do
                           BattleCommand.new(name: "Yell"),
                           BattleCommand.new(name: "Run")
                         ],
-                        escaped: true,
                         map: @map,
                         location: Couple.new(1,1))
       expect(hero.name).to eq "Hero"

--- a/spec/Event/NPC/npc_spec.rb
+++ b/spec/Event/NPC/npc_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe NPC do
 
     it "correctly assigns custom parameters" do
       john = NPC.new(name: "John",
-                     command: "open",
                      mode: 1,
                      visible: false)
       expect(john.name).to eq "John"

--- a/spec/Event/Shop/shop_spec.rb
+++ b/spec/Event/Shop/shop_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe Shop do
 
     it "correctly assigns custom parameters" do
       box = Shop.new(name: "Box",
-                     command: "shop",
                      mode: 1,
                      visible: false,
                      items: [Item.new])

--- a/spec/Item/Equippable/Helmet/helmet_spec.rb
+++ b/spec/Item/Equippable/Helmet/helmet_spec.rb
@@ -15,8 +15,7 @@ RSpec.describe Helmet do
       big_hat = Helmet.new(name: "Big Hat",
                            price: 20,
                            consumable: true,
-                           stat_change: {attack: 2, defense: 2},
-                           type: :weapon)
+                           stat_change: {attack: 2, defense: 2})
       expect(big_hat.name).to eq "Big Hat"
       expect(big_hat.price).to eq 20
       expect(big_hat.consumable).to eq true

--- a/spec/Item/Equippable/Legs/legs_spec.rb
+++ b/spec/Item/Equippable/Legs/legs_spec.rb
@@ -15,8 +15,7 @@ RSpec.describe Legs do
       pants = Legs.new(name: "Pants",
                        price: 20,
                        consumable: true,
-                       stat_change: {attack: 2, defense: 2},
-                       type: :helmet)
+                       stat_change: {attack: 2, defense: 2})
       expect(pants.name).to eq "Pants"
       expect(pants.price).to eq 20
       expect(pants.consumable).to eq true

--- a/spec/Item/Equippable/Shield/shield_spec.rb
+++ b/spec/Item/Equippable/Shield/shield_spec.rb
@@ -15,8 +15,7 @@ RSpec.describe Shield do
       buckler = Shield.new(name: "Buckler",
                            price: 20,
                            consumable: true,
-                           stat_change: {attack: 2, defense: 2},
-                           type: :helmet)
+                           stat_change: {attack: 2, defense: 2})
       expect(buckler.name).to eq "Buckler"
       expect(buckler.price).to eq 20
       expect(buckler.consumable).to eq true

--- a/spec/Item/Equippable/Torso/torso_spec.rb
+++ b/spec/Item/Equippable/Torso/torso_spec.rb
@@ -15,8 +15,7 @@ RSpec.describe Torso do
       shirt = Torso.new(name: "Shirt",
                         price: 20,
                         consumable: true,
-                        stat_change: {attack: 2, defense: 2},
-                        type: :helmet)
+                        stat_change: {attack: 2, defense: 2})
       expect(shirt.name).to eq "Shirt"
       expect(shirt.price).to eq 20
       expect(shirt.consumable).to eq true

--- a/spec/Item/Equippable/Weapon/weapon_spec.rb
+++ b/spec/Item/Equippable/Weapon/weapon_spec.rb
@@ -15,8 +15,7 @@ RSpec.describe Weapon do
       pencil = Weapon.new(name: "Pencil",
                            price: 20,
                            consumable: true,
-                           stat_change: {attack: 2, defense: 2},
-                           type: :helmet)
+                           stat_change: {attack: 2, defense: 2})
       expect(pencil.name).to eq "Pencil"
       expect(pencil.price).to eq 20
       expect(pencil.consumable).to eq true

--- a/spec/Item/Equippable/equippable_spec.rb
+++ b/spec/Item/Equippable/equippable_spec.rb
@@ -15,8 +15,7 @@ RSpec.describe Equippable do
       big_hat = Equippable.new(name: "Big Hat",
                                price: 20,
                                consumable: true,
-                               stat_change: {attack: 2, defense: 2, agility: 2},
-                               type: :weapon)
+                               stat_change: {attack: 2, defense: 2, agility: 2})
       expect(big_hat.name).to eq "Big Hat"
       expect(big_hat.price).to eq 20
       expect(big_hat.consumable).to eq true


### PR DESCRIPTION
There are many good things and only one "ehhh...." thing about keyword arguments.

The "ehhh...." thing is that one must supply all default arguments in the constructors of subclasses even when those default values are already provided in the superclass.

I believe this update optimizes for the end-user, however. This feature removes the need to check the previously-used `params` hash for `nil` values, saving lots of code. Additionally, factory classes are developed with a gain of 281% efficiency. Lastly, this removes bugs that were present in the previous version. Those constructors did not even actually use default parameters at all!!

#33