### PR TITLE
Command history feature

### DIFF
--- a/lib/util.rb
+++ b/lib/util.rb
@@ -1,4 +1,5 @@
 require 'yaml'
+require 'readline'
 
 # Stores a pair of values.
 class Couple
@@ -20,9 +21,22 @@ end
 
 # Simple player input script.
 def player_input
-  print "> "
-  input = gets.chomp
-  puts "\n"
+
+  begin
+    # When using Readline, rspec actually prompts the user for input, freezing the tests.
+    if(ENV['TEST'] == 'rspec') 
+      input = gets.chomp
+    else
+      input = Readline.readline("> ", false)
+    end
+  rescue Interrupt => e
+    puts "The game was interrupted."
+  end
+  
+  if ((input.size > 1) and (input != Readline::HISTORY.to_a[-1]))
+    Readline::HISTORY.push(input)
+  end
+
   return input
 end
 

--- a/lib/util.rb
+++ b/lib/util.rb
@@ -28,6 +28,7 @@ def player_input
       input = gets.chomp
     else
       input = Readline.readline("> ", false)
+      puts "\n"
     end
   rescue Interrupt => e
     puts "The game was interrupted."

--- a/spec/util_spec.rb
+++ b/spec/util_spec.rb
@@ -1,0 +1,77 @@
+RSpec.describe do
+  
+  context "add to history" do 
+    context "distinct commands" do
+      it "should correctly add all commands to the history" do
+        Readline::HISTORY.pop until Readline::HISTORY.size <= 0
+
+        __stdin("kick\n") do
+            player_input
+        end
+
+        __stdin("use\n") do
+            player_input
+        end
+
+        __stdin("inv\n") do
+            player_input
+        end
+
+        expect(Readline::HISTORY.size).to eq 3
+        expect(Readline::HISTORY[-1]).to eq "inv"
+      end
+    end
+
+    context "sequentially repeated commands" do
+      it "should correctly add only the distinct commands to the history" do
+        Readline::HISTORY.pop until Readline::HISTORY.size <= 0
+        
+        __stdin("kick\n") do
+            player_input
+        end
+
+        __stdin("kick\n") do
+            player_input
+        end
+
+        __stdin("inv\n") do
+            player_input
+        end
+
+        __stdin("kick\n") do
+            player_input
+        end
+
+        expect(Readline::HISTORY.size).to eq 3
+        expect(Readline::HISTORY[0]).to eq "kick"
+        expect(Readline::HISTORY[1]).to eq "inv"
+      end
+    end
+  end
+
+  context "do not add to history" do
+    context "single character commands" do
+      it "should correctly keep the history empty" do
+        Readline::HISTORY.pop until Readline::HISTORY.size <= 0
+        __stdin("w\n") do
+          player_input
+        end
+
+        __stdin("a\n") do
+          player_input
+        end
+
+        __stdin("s\n") do
+          player_input
+        end
+
+        __stdin("d\n") do
+          player_input
+        end
+
+        expect(Readline::HISTORY.size).to eq 0
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
Requested in #66. Since it is on hold, I'm not sure if I should have implemented it, but I did it anyway.
I just had to replace the input method from `gets.chomp` to `Readline`. (https://ruby-doc.org/stdlib-2.1.0/libdoc/readline/rdoc/Readline.html).
The reason I chose `Readline`, it's because it already provides a history feature, including scrolling up and down with the arrow keys. Unfortunatelly, it doesn't work well with RSpec, so, I had to reuse `gets` in the test enviroment.
I coded so the history would ignore single character commands, since it is faster to type them out, rather than search for them in the history. It also ignores repeated commands typed consecutively.