### PR TITLE
Allow upcase'd input.

### DIFF
--- a/ayara/Event/NPC/ayara.rb
+++ b/ayara/Event/NPC/ayara.rb
@@ -17,13 +17,13 @@ class Andre < NPC
     type("#{@name}: Each player takes five shots -\n")
     type("whoever makes more wins. Would you like\n")
     type("to make a wager (y/n)?: ")
-    input = gets.chomp
+    input = gets.chomp.downcase
     print "\n"
     return if input != 'y'
     
     puts "Current gold in pouch: #{player.gold}."
     type("#{@name}: How much will you wager?: ")
-    input = gets.chomp
+    input = gets.chomp.downcase
     amount = input.to_i
     print "\n"
     
@@ -91,7 +91,7 @@ class Bella < NPC
     else
       type("#{@name}: Oooh.. you have water... ??\n")
       type("May I please have it... (y/n)?: ")
-      input = gets.chomp
+      input = gets.chomp.downcase
       print "\n"
       
       if (input == 'y')
@@ -157,7 +157,7 @@ class John < NPC
       if (player.has_item(@pairs[@current_index].first))
         type("#{@name}: Ah, yes! #{@pairs[@current_index].first.name}!\n")
         type("May I have it (y/n)?: ")
-        input = gets.chomp
+        input = gets.chomp.downcase
         print "\n"
         
         if (input == 'y')

--- a/ayara/Event/ayara.rb
+++ b/ayara/Event/ayara.rb
@@ -16,7 +16,7 @@ class Dojo < Event
     print "#{player.name} enters the Dojo...\n\n"
     type("#{@name}: Ah, #{player.name}, so good to see you.\n")
     type("Would you like to train today (y/n)?: ")
-    input = gets.chomp
+    input = gets.chomp.downcase
     print "\n"
     
     if (input == 'y')
@@ -80,7 +80,7 @@ class SeliaHouse < House
     else
       type("#{@name}: Are you ready to take your cooking\n")
       type("skills to the next level (y/n)?: ")
-      input = gets.chomp
+      input = gets.chomp.downcase
       print "\n"
       
       if (input == 'y')
@@ -144,7 +144,7 @@ class Well < Event
   def run(player)
     if player.has_item(Bucket.new)
       print "Will you fill the Bucket (y/n)?: "
-      input = gets.chomp
+      input = gets.chomp.downcase
       print "\n"
       
       if (input == 'y')

--- a/ayara/Event/pool.rb
+++ b/ayara/Event/pool.rb
@@ -22,7 +22,7 @@ class Pool < Event
           puts "* #{bait.name}"
         end
         print "\nWhich bait will you use?: "
-        input = gets.chomp
+        input = gets.chomp.downcase
         index = player.has_item(input)
         if (!index || (!(player.inventory[index].first.is_a? Bait)))
           print "What?! You don't have THAT!\n\n"

--- a/ayara/Event/stove.rb
+++ b/ayara/Event/stove.rb
@@ -11,7 +11,7 @@ class Stove < Event
     puts "You can cook either a single item or a recipe."
     print "What would you like to cook?: "
     
-    input = gets.chomp
+    input = gets.chomp.downcase
     item_index = player.has_item(input)
     book_index = player.has_item(RecipeBook.new)
     recipe_index = player.inventory[book_index].first.has_recipe(input) if book_index
@@ -38,7 +38,7 @@ class Stove < Event
     recipe = player.inventory[book_index].first.recipes[recipe_index] if recipe_index
     
     print "How many?: "
-    input = gets.chomp
+    input = gets.chomp.downcase
     amount = input.to_i
     
     # Error handling for non-positive amount.

--- a/ayara/Story/intro.rb
+++ b/ayara/Story/intro.rb
@@ -1,6 +1,6 @@
 def get_name
   print "Brave hero, what is thy name?: "
-  input = gets.chomp
+  input = gets.chomp.downcase
   print "\n"
   return input
 end
@@ -9,7 +9,7 @@ def load_game?
   system("clear")
 
   print "Would you like to load the saved game (y/n)?: "
-  input = gets.chomp
+  input = gets.chomp.downcase
   print "\n"
   
   return true if input == 'y'
@@ -20,7 +20,7 @@ def print_intro
   system("clear")
   
   print "Do you know how to play (y/n)?: "
-  input = gets.chomp
+  input = gets.chomp.downcase
   print "\n"
   
   return if input != 'n'

--- a/lib/Entity/player.rb
+++ b/lib/Entity/player.rb
@@ -82,7 +82,7 @@ class Player < Entity
       print_inventory
       puts "Which item would you like to use?"
       print "(or type 'pass' to forfeit the turn): "
-      input = gets.chomp
+      input = gets.chomp.downcase
 
       print "\n"
 
@@ -103,7 +103,7 @@ class Player < Entity
     while !whom
       puts "On whom will you use the item (#{@name} or #{enemy.name})?"
       print "(or type 'pass' to forfeit the turn): "
-      input = gets.chomp
+      input = gets.chomp.downcase
 
       print "\n"
 

--- a/lib/Event/Shop/shop.rb
+++ b/lib/Event/Shop/shop.rb
@@ -44,7 +44,7 @@ class Shop < Event
     puts "Current gold in your pouch: #{player.gold}."
     print "Would you like to buy, sell, or exit?: "
 
-    input = gets.chomp
+    input = gets.chomp.downcase
     print "\n"
 
     while (input.casecmp("exit") != 0)
@@ -54,7 +54,7 @@ class Shop < Event
         print_items
         print "What would you like (or none)?: "
 
-        name = gets.chomp
+        name = gets.chomp.downcase
         index = has_item(name)
 
         # Case: The player does not want to buy an item.
@@ -64,7 +64,7 @@ class Shop < Event
         elsif index
           item = @items[index]
           print "How many do you want?: "
-          amount_to_buy = gets.chomp
+          amount_to_buy = gets.chomp.downcase
           total_cost = amount_to_buy.to_i * item.price
 
           # Case: The player does not have enough gold.
@@ -101,7 +101,7 @@ class Shop < Event
           player.print_inventory
 
           print "What would you like to sell? (or none): "
-          name = gets.chomp
+          name = gets.chomp.downcase
           index = player.has_item(name)
 
           # Case: The player does not want to sell an item.
@@ -117,7 +117,7 @@ class Shop < Event
             item = player.inventory[index].first
             puts "\nI'll buy that for #{item.price / 2} gold."
             print "How many do you want to sell?: "
-            amount_to_sell = gets.chomp
+            amount_to_sell = gets.chomp.downcase
 
             # Case: The player specifies more than the amount in its inventory.
             if (amount_to_sell.to_i > item_count)
@@ -153,7 +153,7 @@ class Shop < Event
       # Greeting for subsequent interactions (following the initial).
       puts "Current gold in your pouch: #{player.gold}."
       print "Would you like to buy, sell, or exit?: "
-      input = gets.chomp
+      input = gets.chomp.downcase
       print "\n"
     end
     print "#{player.name} has left #{@name}.\n\n"

--- a/lib/util.rb
+++ b/lib/util.rb
@@ -21,7 +21,7 @@ end
 # Simple player input script.
 def player_input
   print "> "
-  input = gets.chomp
+  input = gets.chomp.downcase
   puts "\n"
   return input
 end


### PR DESCRIPTION
Currently, when presented with a (y/n) question if you respond with Y or N, it will prevent the action from being carried out, either by returning an empty prompt or (in the case of Selia's house) slamming a door in your face (how rude). Simply converting all input to downcase resolves this small issue. 

-- Example -- 
          · ■ ■ · · 
          · △ ■ ■ · 
          □ □ ¶ ■ ■ 
          · · · · ■ 
          △ · · · · 

This is the dojo, where martial arts
students come to hone their abilities.

* Special commands: enter

> enter

penguinstyles enters the Dojo...

Sensei: Ah, penguinstyles, so good to see you.
Would you like to train today (y/n)?: Y

> 