### PR TITLE
Convert Entity stats to a Hash #103

### DIFF
--- a/lib/goby/battle/attack.rb
+++ b/lib/goby/battle/attack.rb
@@ -48,10 +48,8 @@ module Goby
         # Damage the enemy.
         original_enemy_hp = enemy.stats[:hp]
         damage = calculate_damage(user, enemy)
-        enemy.stats[:hp] -= damage
-
-        # Prevent HP < 0.
-        enemy.stats[:hp] = 0 if enemy.stats[:hp].negative?
+        old_hp = enemy.stats[:hp]
+        enemy.set_stats(hp: old_hp - damage)
 
         type("#{user.name} uses #{@name}!\n\n")
         type("#{enemy.name} takes #{original_enemy_hp - enemy.stats[:hp]} damage!\n")

--- a/lib/goby/battle/attack.rb
+++ b/lib/goby/battle/attack.rb
@@ -25,14 +25,14 @@ module Goby
       inflict = Random.rand(0.05..0.15).round(2)
       multiplier = 1
 
-      if enemy.defense > user.attack
-        multiplier = 1 - ((enemy.defense * 0.1) - (user.attack * inflict))
+      if enemy.stats[:defense] > user.stats[:attack]
+        multiplier = 1 - ((enemy.stats[:defense] * 0.1) - (user.stats[:attack] * inflict))
 
         # Prevent a negative multiplier.
         multiplier = 0 if multiplier.negative?
 
       else
-        multiplier = 1 + ((user.attack * inflict) - (enemy.defense * 0.1))
+        multiplier = 1 + ((user.stats[:attack] * inflict) - (enemy.stats[:defense] * 0.1))
       end
 
       return (@strength * multiplier).round(0)
@@ -46,16 +46,16 @@ module Goby
       if (Random.rand(100) < @success_rate)
 
         # Damage the enemy.
-        original_enemy_hp = enemy.hp
+        original_enemy_hp = enemy.stats[:hp]
         damage = calculate_damage(user, enemy)
-        enemy.hp -= damage
+        enemy.stats[:hp] -= damage
 
         # Prevent HP < 0.
-        enemy.hp = 0 if enemy.hp.negative?
+        enemy.stats[:hp] = 0 if enemy.stats[:hp].negative?
 
         type("#{user.name} uses #{@name}!\n\n")
-        type("#{enemy.name} takes #{original_enemy_hp - enemy.hp} damage!\n")
-        type("#{enemy.name}'s HP: #{original_enemy_hp} -> #{enemy.hp}\n\n")
+        type("#{enemy.name} takes #{original_enemy_hp - enemy.stats[:hp]} damage!\n")
+        type("#{enemy.name}'s HP: #{original_enemy_hp} -> #{enemy.stats[:hp]}\n\n")
 
       else
         type("#{user.name} tries to use #{@name}, but it fails.\n\n")

--- a/lib/goby/entity/entity.rb
+++ b/lib/goby/entity/entity.rb
@@ -10,8 +10,6 @@ module Goby
     NO_SUCH_ITEM_ERROR = "What?! You don't have THAT!\n\n"
     # Error when the entity specifies an item not equipped.
     NOT_EQUIPPED_ERROR = "You are not equipping THAT!\n\n"
-    # Error when set_stats called with non-numberic values.
-    SET_STATS_ERROR = "That cannot be done. All stats must be a number\n\n"
 
     # @param [String] name the name.
     # @param [Hash] stats hash of stats
@@ -306,7 +304,7 @@ module Goby
 
     # Sets stats
     #
-    # @param [Hash] key value pairs of stats
+    # @param [Hash] passed_in_stats value pairs of stats
     def set_stats(passed_in_stats)
       current_stats = @stats || { max_hp: 1, hp: nil, attack: 1, defense: 1, agility: 1 }
       constructed_stats = current_stats.merge(passed_in_stats)
@@ -315,14 +313,9 @@ module Goby
       constructed_stats[:hp] = constructed_stats[:hp] || constructed_stats[:max_hp]
       # Prevent HP > max HP.
       constructed_stats[:max_hp] = constructed_stats[:hp] if constructed_stats[:hp] > constructed_stats[:max_hp]
-      #ensure all stats are numbers
-      if constructed_stats.values.any? {|value| !value.is_a?(Integer)}
-        print SET_STATS_ERROR
-        return
-      end
       #ensure hp is at least 0
       constructed_stats[:hp] = constructed_stats[:hp] > 0 ? constructed_stats[:hp] : 0
-      #ensure all other stats >= 0
+      #ensure all other stats > 0
       constructed_stats.each do |key,value|
         if [:max_hp, :attack, :defense, :agility].include?(key)
           constructed_stats[key] = value.negative? ? 1 : value
@@ -332,6 +325,9 @@ module Goby
       @stats = constructed_stats
     end
 
+    # getter for stats
+    #
+    # @return [Object]
     def stats
       # attr_reader makes sure stats cannot be set via stats=
       # freeze makes sure that stats []= cannot be used

--- a/lib/goby/entity/entity.rb
+++ b/lib/goby/entity/entity.rb
@@ -12,27 +12,14 @@ module Goby
     NOT_EQUIPPED_ERROR = "You are not equipping THAT!\n\n"
 
     # @param [String] name the name.
-    # @param [Integer] max_hp the greatest amount of health.
-    # @param [Integer] hp the current amount of health.
-    # @param [Integer] attack the strength in battle.
-    # @param [Integer] defense the prevention of attack power on oneself.
-    # @param [Integer] agility the speed in battle.
+    # @param [Hash] stats hash of stats
     # @param [[Couple(Item, Integer)]] inventory a list of pairs of items and their respective amounts.
     # @param [Integer] gold the currency used for economical transactions.
     # @param [[BattleCommand]] battle_commands the commands that can be used in battle.
     # @param [Hash] outfit the collection of equippable items currently worn.
-    def initialize(name: "Entity", max_hp: 1, hp: nil, attack: 1, defense: 1, agility: 1,
-                   inventory: [], gold: 0, battle_commands: [], outfit: {})
+    def initialize(name: "Entity", stats: {}, inventory: [], gold: 0, battle_commands: [], outfit: {})
       @name = name
-      @max_hp = max_hp
-      @hp = hp.nil? ? max_hp : hp
-
-      # Prevent HP > max HP.
-      @max_hp = @hp if @hp > @max_hp
-
-      @attack = attack
-      @defense = defense
-      @agility = agility
+      @stats = set_stats(stats)
       @inventory = inventory
       set_gold(gold)
 
@@ -204,10 +191,10 @@ module Goby
     # TODO: encapsulate print_stats and print_equipment in own functions.
     def print_status
       puts "Stats:"
-      puts "* HP: #{@hp}/#{@max_hp}"
-      puts "* Attack: #{@attack}"
-      puts "* Defense: #{@defense}"
-      puts "* Agility: #{@agility}"
+      puts "* HP: #{@stats[:hp]}/#{@stats[:max_hp]}"
+      puts "* Attack: #{@stats[:attack]}"
+      puts "* Defense: #{@stats[:defense]}"
+      puts "* Agility: #{@stats[:agility]}"
       print "\n"
 
       puts "Equipment:"
@@ -316,10 +303,8 @@ module Goby
     end
 
     attr_accessor :name
-    attr_accessor :max_hp, :hp
-    attr_accessor :attack
-    attr_accessor :defense
-    attr_accessor :agility
+
+    attr_accessor :stats
 
     attr_accessor :inventory
     attr_reader :gold
@@ -336,6 +321,16 @@ module Goby
       # from decreasing below 0.
       def check_and_set_gold
         @gold = 0 if @gold.negative?
+      end
+
+      def set_stats(passed_in_stats)
+        stats = {max_hp: 1, hp: nil, attack: 1, defense: 1, agility: 1}.merge(passed_in_stats)
+
+        # Set hp to max_hp if hp not specified
+        stats[:hp] = stats[:hp] || stats[:max_hp]
+        # Prevent HP > max HP.
+        stats[:max_hp] = stats[:hp] if stats[:hp] > stats[:max_hp]
+        stats
       end
 
   end

--- a/lib/goby/entity/entity.rb
+++ b/lib/goby/entity/entity.rb
@@ -311,8 +311,8 @@ module Goby
 
       # Set hp to max_hp if hp not specified
       constructed_stats[:hp] = constructed_stats[:hp] || constructed_stats[:max_hp]
-      # Prevent HP > max HP.
-      constructed_stats[:max_hp] = constructed_stats[:hp] if constructed_stats[:hp] > constructed_stats[:max_hp]
+      # hp should not be greater than max_hp
+      constructed_stats[:hp] = [constructed_stats[:hp], constructed_stats[:max_hp]].min
       #ensure hp is at least 0
       constructed_stats[:hp] = constructed_stats[:hp] > 0 ? constructed_stats[:hp] : 0
       #ensure all other stats > 0

--- a/lib/goby/entity/monster.rb
+++ b/lib/goby/entity/monster.rb
@@ -6,22 +6,17 @@ module Goby
   class Monster < Entity
 
     # @param [String] name the name.
-    # @param [Integer] max_hp the greatest amount of health.
-    # @param [Integer] hp the current amount of health.
-    # @param [Integer] attack the strength in battle.
-    # @param [Integer] defense the prevention of attack power on oneself.
-    # @param [Integer] agility the speed in battle.
+    # @param [Hash] stats hash of stats
     # @param [[Couple(Item, Integer)]] inventory an array of pairs of items and their respective amounts.
     # @param [Integer] gold the max amount of gold that can be rewarded to the opponent.
     # @param [[BattleCommand]] battle_commands the commands that can be used in battle.
     # @param [Hash] outfit the coolection of equippable items currently worn.
     # @param [String] message the monster's battle cry.
     # @param [[Couple(Item, Integer)]] treasures an array of treasures and the likelihood of receiving each.
-    def initialize(name: "Monster", max_hp: 1, hp: nil, attack: 1, defense: 1, agility: 1,
+    def initialize(name: "Monster", stats: {max_hp: 1, hp: nil, attack: 1, defense: 1, agility: 1},
                    inventory: [], gold: 0, battle_commands: [], outfit: {}, message: "!!!",
                    treasures: [])
-      super(name: name, max_hp: max_hp, hp: hp, attack: attack, defense: defense, agility: agility,
-            inventory: inventory, gold: gold, battle_commands: battle_commands, outfit: outfit)
+      super(name: name, stats: stats, inventory: inventory, gold: gold, battle_commands: battle_commands, outfit: outfit)
       @message = message
       @treasures = treasures
 

--- a/lib/goby/entity/monster.rb
+++ b/lib/goby/entity/monster.rb
@@ -13,8 +13,7 @@ module Goby
     # @param [Hash] outfit the coolection of equippable items currently worn.
     # @param [String] message the monster's battle cry.
     # @param [[Couple(Item, Integer)]] treasures an array of treasures and the likelihood of receiving each.
-    def initialize(name: "Monster", stats: {max_hp: 1, hp: nil, attack: 1, defense: 1, agility: 1},
-                   inventory: [], gold: 0, battle_commands: [], outfit: {}, message: "!!!",
+    def initialize(name: "Monster", stats: {}, inventory: [], gold: 0, battle_commands: [], outfit: {}, message: "!!!",
                    treasures: [])
       super(name: name, stats: stats, inventory: inventory, gold: gold, battle_commands: battle_commands, outfit: outfit)
       @message = message

--- a/lib/goby/entity/player.rb
+++ b/lib/goby/entity/player.rb
@@ -19,22 +19,17 @@ module Goby
     VIEW_DISTANCE = 2
 
     # @param [String] name the name.
-    # @param [Integer] max_hp the greatest amount of health.
-    # @param [Integer] hp the current amount of health.
-    # @param [Integer] attack the strength in battle.
-    # @param [Integer] defense the prevention of attack power on oneself.
-    # @param [Integer] agility the speed in battle.
+    # @param [Hash] stats hash of stats
     # @param [[Couple(Item, Integer)]] inventory a list of pairs of items and their respective amounts.
     # @param [Integer] gold the currency used for economical transactions.
     # @param [[BattleCommand]] battle_commands the commands that can be used in battle.
     # @param [Hash] outfit the collection of equippable items currently worn.
     # @param [Map] map the map on which the player is located.
     # @param [Couple(Integer,Integer)] location the 2D index of the map (the exact tile).
-    def initialize(name: "Player", max_hp: 1, hp: nil, attack: 1, defense: 1, agility: 1,
+    def initialize(name: "Player", stats: {max_hp: 1, hp: nil, attack: 1, defense: 1, agility: 1},
                    inventory: [], gold: 0, battle_commands: [], outfit: {}, map: DEFAULT_MAP,
                    location: DEFAULT_LOCATION)
-      super(name: name, max_hp: max_hp, hp: hp, attack: attack, defense: defense, agility: agility,
-            inventory: inventory, gold: gold, battle_commands: battle_commands, outfit: outfit)
+      super(name: name, stats: stats, inventory: inventory, gold: gold, battle_commands: battle_commands, outfit: outfit)
 
       @map = DEFAULT_MAP
       @location = DEFAULT_LOCATION
@@ -59,7 +54,7 @@ module Goby
       puts "#{monster.message}\n"
       type("You've run into a vicious #{monster.name}!\n\n")
 
-      while hp.positive?
+      while stats[:hp].positive?
         # Both choose an attack.
         player_attack = choose_attack
 
@@ -91,17 +86,17 @@ module Goby
             return
           end
 
-          break if monster.hp.nonpositive? || hp.nonpositive?
+          break if monster.stats[:hp].nonpositive? || stats[:hp].nonpositive?
 
         end
 
-        break if monster.hp.nonpositive? || hp.nonpositive?
+        break if monster.stats[:hp].nonpositive? || stats[:hp].nonpositive?
 
       end
 
-      die if hp.nonpositive?
+      die if stats[:hp].nonpositive?
 
-      if monster.hp.nonpositive?
+      if monster.stats[:hp].nonpositive?
         type("You defeated the #{monster.name}!\n\n")
 
         # Determine the rewards for defeating the monster.
@@ -204,7 +199,7 @@ module Goby
       sleep(2) unless ENV['TEST']
 
       # Heal the player.
-      @hp = @max_hp
+      @stats[:hp] = @stats[:max_hp]
     end
 
     # Moves the player down. Increases 'y' coordinate by 1.
@@ -328,8 +323,8 @@ module Goby
     # @param [Monster] monster the opponent with whom the player is competing.
     # @return [Boolean] true when player should go first. Otherwise, false.
     def sample_agilities(monster)
-      sum = monster.agility + agility
-      Random.rand(sum) < agility
+      sum = monster.stats[:agility] + stats[:agility]
+      Random.rand(sum) < stats[:agility]
     end
 
     # Updates the 'seen' attributes of the tiles on the player's current map.

--- a/lib/goby/entity/player.rb
+++ b/lib/goby/entity/player.rb
@@ -26,8 +26,7 @@ module Goby
     # @param [Hash] outfit the collection of equippable items currently worn.
     # @param [Map] map the map on which the player is located.
     # @param [Couple(Integer,Integer)] location the 2D index of the map (the exact tile).
-    def initialize(name: "Player", stats: {max_hp: 1, hp: nil, attack: 1, defense: 1, agility: 1},
-                   inventory: [], gold: 0, battle_commands: [], outfit: {}, map: DEFAULT_MAP,
+    def initialize(name: "Player", stats: {}, inventory: [], gold: 0, battle_commands: [], outfit: {}, map: DEFAULT_MAP,
                    location: DEFAULT_LOCATION)
       super(name: name, stats: stats, inventory: inventory, gold: gold, battle_commands: battle_commands, outfit: outfit)
 
@@ -199,7 +198,7 @@ module Goby
       sleep(2) unless ENV['TEST']
 
       # Heal the player.
-      @stats[:hp] = @stats[:max_hp]
+      set_stats(hp: @stats[:max_hp])
     end
 
     # Moves the player down. Increases 'y' coordinate by 1.

--- a/lib/goby/item/equippable.rb
+++ b/lib/goby/item/equippable.rb
@@ -25,15 +25,11 @@ module Goby
     def alter_stats(entity, equipping)
 
       # Alter the stats as appropriate.
-      # TODO: this can be simplified by creating entity.stats hash..?
+      stats = entity.stats
       if equipping
-        entity.attack += stat_change[:attack] if stat_change[:attack]
-        entity.defense += stat_change[:defense] if stat_change[:defense]
-        entity.agility += stat_change[:agility] if stat_change[:agility]
+        adjust_stats_with_operator(stats, :+)
       else
-        entity.attack -= stat_change[:attack] if stat_change[:attack]
-        entity.defense -= stat_change[:defense] if stat_change[:defense]
-        entity.agility -= stat_change[:agility] if stat_change[:agility]
+        adjust_stats_with_operator(stats, :-)
       end
 
     end
@@ -72,6 +68,14 @@ module Goby
     def use(user, entity)
       print "Type 'equip #{@name}' to equip this item.\n\n"
     end
+
+    private
+
+      def adjust_stats_with_operator(stats, operator)
+        [:attack, :defense, :agility].each do |stat|
+          stats[stat]= stats[stat].send(operator, stat_change[stat]) if stat_change[stat]
+        end
+      end
 
   end
 

--- a/lib/goby/item/equippable.rb
+++ b/lib/goby/item/equippable.rb
@@ -25,11 +25,10 @@ module Goby
     def alter_stats(entity, equipping)
 
       # Alter the stats as appropriate.
-      stats = entity.stats
       if equipping
-        adjust_stats_with_operator(stats, :+)
+        adjust_stats_with_operator(entity, :+)
       else
-        adjust_stats_with_operator(stats, :-)
+        adjust_stats_with_operator(entity, :-)
       end
 
     end
@@ -71,10 +70,13 @@ module Goby
 
     private
 
-      def adjust_stats_with_operator(stats, operator)
-        [:attack, :defense, :agility].each do |stat|
-          stats[stat]= stats[stat].send(operator, stat_change[stat]) if stat_change[stat]
+      #Increase or decrease stats if there is a corresponding stat change from item
+      def adjust_stats_with_operator(entity, operator)
+        stats_to_change = entity.stats.dup
+        [:attack, :defense, :agility, :max_hp].each do |stat|
+          stats_to_change[stat]= stats_to_change[stat].send(operator, stat_change[stat]) if stat_change[stat]
         end
+        entity.set_stats(stats_to_change)
       end
 
   end

--- a/lib/goby/item/equippable.rb
+++ b/lib/goby/item/equippable.rb
@@ -23,14 +23,24 @@ module Goby
     # @param [Boolean] equipping flag for when the item is being equipped or unequipped.
     # @todo ensure stats cannot go below zero (but does it matter..?).
     def alter_stats(entity, equipping)
-
-      # Alter the stats as appropriate.
+      stats_to_change = entity.stats.dup
+      affected_stats = [:attack, :defense, :agility, :max_hp]
       if equipping
-        adjust_stats_with_operator(entity, :+)
+        operator = :+
       else
-        adjust_stats_with_operator(entity, :-)
+        operator = :-
+        stat_change[:hp] = stat_change[:max_hp]
+        affected_stats << :hp
       end
 
+      affected_stats.each do |stat|
+        stats_to_change[stat]= stats_to_change[stat].send(operator, stat_change[stat]) if stat_change[stat]
+      end
+      #do not kill entity by unequipping
+      if stats_to_change[:hp] < 1
+        stats_to_change[:hp] = 1
+      end
+      entity.set_stats(stats_to_change)
     end
 
     # Equips onto the entity and changes the entity's attributes accordingly.
@@ -67,17 +77,6 @@ module Goby
     def use(user, entity)
       print "Type 'equip #{@name}' to equip this item.\n\n"
     end
-
-    private
-
-      #Increase or decrease stats if there is a corresponding stat change from item
-      def adjust_stats_with_operator(entity, operator)
-        stats_to_change = entity.stats.dup
-        [:attack, :defense, :agility, :max_hp].each do |stat|
-          stats_to_change[stat]= stats_to_change[stat].send(operator, stat_change[stat]) if stat_change[stat]
-        end
-        entity.set_stats(stats_to_change)
-      end
 
   end
 

--- a/lib/goby/item/equippable.rb
+++ b/lib/goby/item/equippable.rb
@@ -29,18 +29,18 @@ module Goby
         operator = :+
       else
         operator = :-
-        stat_change[:hp] = stat_change[:max_hp]
-        affected_stats << :hp
       end
 
       affected_stats.each do |stat|
         stats_to_change[stat]= stats_to_change[stat].send(operator, stat_change[stat]) if stat_change[stat]
       end
-      #do not kill entity by unequipping
-      if stats_to_change[:hp] < 1
-        stats_to_change[:hp] = 1
-      end
+
       entity.set_stats(stats_to_change)
+
+      #do not kill entity by unequipping
+      if entity.stats[:hp] < 1
+        entity.set_stats(hp: 1)
+      end
     end
 
     # Equips onto the entity and changes the entity's attributes accordingly.

--- a/lib/goby/item/food.rb
+++ b/lib/goby/item/food.rb
@@ -20,12 +20,12 @@ module Goby
     # @param [Entity] user the one using the food.
     # @param [Entity] entity the one on whom the food is used.
     def use(user, entity)
-      if entity.hp + recovers > entity.max_hp
-        this_recover = entity.max_hp - entity.hp
-        entity.hp = entity.max_hp
+      if entity.stats[:hp] + recovers > entity.stats[:max_hp]
+        this_recover = entity.stats[:max_hp] - entity.stats[:hp]
+        entity.stats[:hp] = entity.stats[:max_hp]
       else
         this_recover = @recovers
-        entity.hp += @recovers
+        entity.stats[:hp] += @recovers
       end
 
       # Helpful output.
@@ -36,7 +36,7 @@ module Goby
         print " on #{entity.name}!\n#{entity.name} "
       end
       print "recovers #{this_recover} HP!\n\n"
-      print "#{entity.name}'s HP: #{entity.hp}/#{entity.max_hp}\n\n"
+      print "#{entity.name}'s HP: #{entity.stats[:hp]}/#{entity.stats[:max_hp]}\n\n"
 
     end
 

--- a/lib/goby/item/food.rb
+++ b/lib/goby/item/food.rb
@@ -22,10 +22,11 @@ module Goby
     def use(user, entity)
       if entity.stats[:hp] + recovers > entity.stats[:max_hp]
         this_recover = entity.stats[:max_hp] - entity.stats[:hp]
-        entity.stats[:hp] = entity.stats[:max_hp]
+        heal_entity(entity, entity.stats[:max_hp])
       else
+        current_hp = entity.stats[:hp]
         this_recover = @recovers
-        entity.stats[:hp] += @recovers
+        heal_entity(entity, current_hp + this_recover)
       end
 
       # Helpful output.
@@ -42,6 +43,13 @@ module Goby
 
     # The amount of HP that the food recovers.
     attr_reader :recovers
+
+    private
+
+      #sets the hp of entity to new_hp
+      def heal_entity(entity, new_hp)
+        entity.set_stats(hp: new_hp)
+      end
 
   end
 

--- a/spec/goby/battle/attack_spec.rb
+++ b/spec/goby/battle/attack_spec.rb
@@ -3,8 +3,8 @@ require 'goby'
 RSpec.describe Goby::Attack do
 
   before(:each) do
-    @user = Player.new(max_hp: 50, attack: 6, defense: 4)
-    @enemy = Monster.new(max_hp: 30, attack: 3, defense: 2)
+    @user = Player.new(stats: { max_hp: 50, attack: 6, defense: 4 })
+    @enemy = Monster.new(stats: {max_hp: 30, attack: 3, defense: 2})
     @attack = Attack.new(strength: 5)
     @cry = Attack.new(name: "Cry", success_rate: 0)
   end
@@ -49,18 +49,18 @@ RSpec.describe Goby::Attack do
   context "run" do
     it "does the appropriate amount of damage for attack > defense" do
       @attack.run(@user, @enemy)
-      expect(@enemy.hp).to be_between(21, 24)
+      expect(@enemy.stats[:hp]).to be_between(21, 24)
     end
 
     it "prevents the enemy's HP from falling below 0" do
-      @user.attack = 1000
+      @user.stats[:attack] = 1000
       @attack.run(@user, @enemy)
-      expect(@enemy.hp).to be_zero
+      expect(@enemy.stats[:hp]).to be_zero
     end
 
     it "does the appropriate amount of damage for defense > attack" do
       @attack.run(@enemy, @user)
-      expect(@user.hp).to be_between(45, 46)
+      expect(@user.stats[:hp]).to be_between(45, 46)
     end
 
     it "prints an appropriate message for a failed attack" do
@@ -82,7 +82,7 @@ RSpec.describe Goby::Attack do
     end
 
     it "defaults to 0 when the defense is very high" do
-      @enemy.defense = 100
+      @enemy.stats[:defense] = 100
       damage = @attack.calculate_damage(@user, @enemy)
       expect(damage).to be_zero
     end

--- a/spec/goby/battle/attack_spec.rb
+++ b/spec/goby/battle/attack_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Goby::Attack do
     end
 
     it "prevents the enemy's HP from falling below 0" do
-      @user.stats[:attack] = 1000
+      @user.set_stats(attack: 100)
       @attack.run(@user, @enemy)
       expect(@enemy.stats[:hp]).to be_zero
     end
@@ -82,7 +82,7 @@ RSpec.describe Goby::Attack do
     end
 
     it "defaults to 0 when the defense is very high" do
-      @enemy.stats[:defense] = 100
+      @enemy.set_stats(defense: 100)
       damage = @attack.calculate_damage(@user, @enemy)
       expect(damage).to be_zero
     end

--- a/spec/goby/battle/use_spec.rb
+++ b/spec/goby/battle/use_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe Use do
 
   context "run" do
     before(:each) do
-      @player = Player.new(max_hp: 10, hp: 3, battle_commands: [@use],
+      @player = Player.new(stats: { max_hp: 10, hp: 3 },
+                           battle_commands: [@use],
                            inventory: [Couple.new(Food.new(recovers: 5), 1)])
       @monster = Monster.new
     end
@@ -23,7 +24,7 @@ RSpec.describe Use do
       # RSpec input example. Also see spec_helper.rb for __stdin method.
       __stdin("food\n", "player\n") do
         @use.run(@player, @monster)
-        expect(@player.hp).to eq 8
+        expect(@player.stats[:hp]).to eq 8
         expect(@player.inventory.empty?).to be true
       end
     end

--- a/spec/goby/entity/entity_spec.rb
+++ b/spec/goby/entity/entity_spec.rb
@@ -6,11 +6,12 @@ RSpec.describe Entity do
     it "has the correct default parameters" do
       entity = Entity.new
       expect(entity.name).to eq "Entity"
-      expect(entity.max_hp).to eq 1
-      expect(entity.hp).to eq 1
-      expect(entity.attack). to eq 1
-      expect(entity.defense).to eq 1
-      expect(entity.agility).to eq 1
+      stats = entity.stats
+      expect(stats[:max_hp]).to eq 1
+      expect(stats[:hp]).to eq 1
+      expect(stats[:attack]). to eq 1
+      expect(stats[:defense]).to eq 1
+      expect(stats[:agility]).to eq 1
       expect(entity.inventory).to eq Array.new
       expect(entity.gold).to eq 0
       expect(entity.battle_commands).to eq Array.new
@@ -19,11 +20,11 @@ RSpec.describe Entity do
 
     it "correctly assigns custom parameters" do
       hero = Entity.new(name: "Hero",
-                        max_hp: 50,
-                        hp: 35,
-                        attack: 12,
-                        defense: 4,
-                        agility: 9,
+                        stats: { max_hp: 50,
+                                hp: 35,
+                                attack: 12,
+                                defense: 4,
+                                agility: 9 },
                         inventory: [Couple.new(Item.new, 1)],
                         gold: 10,
                         outfit: { weapon: Weapon.new(
@@ -38,12 +39,13 @@ RSpec.describe Entity do
                           Attack.new(name: "Kick")
                         ])
       expect(hero.name).to eq "Hero"
-      expect(hero.max_hp).to eq 50
-      expect(hero.hp).to eq 35
+      stats = hero.stats
+      expect(stats[:max_hp]).to eq 50
+      expect(stats[:hp]).to eq 35
       # Attack & defense increase due to the equipped items.
-      expect(hero.attack).to eq 16
-      expect(hero.defense).to eq 10
-      expect(hero.agility).to eq 13
+      expect(stats[:attack]).to eq 16
+      expect(stats[:defense]).to eq 10
+      expect(stats[:agility]).to eq 13
       expect(hero.inventory).to eq [Couple.new(Item.new, 1)]
       expect(hero.gold).to eq 10
       expect(hero.outfit[:weapon]).to eq Weapon.new
@@ -57,15 +59,16 @@ RSpec.describe Entity do
     end
 
     it "assigns default keyword arguments as appropriate" do
-      entity = Entity.new(max_hp: 7,
-                        defense: 9,
+      entity = Entity.new(stats: { max_hp: 7,
+                        defense: 9 },
                         gold: 3)
       expect(entity.name).to eq "Entity"
-      expect(entity.max_hp).to eq 7
-      expect(entity.hp).to eq 7
-      expect(entity.attack).to eq 1
-      expect(entity.defense).to eq 9
-      expect(entity.agility).to eq 1
+      stats = entity.stats
+      expect(stats[:max_hp]).to eq 7
+      expect(stats[:hp]).to eq 7
+      expect(stats[:attack]).to eq 1
+      expect(stats[:defense]).to eq 9
+      expect(stats[:agility]).to eq 1
       expect(entity.inventory).to eq []
       expect(entity.gold).to eq 3
       expect(entity.battle_commands).to eq []
@@ -228,7 +231,7 @@ RSpec.describe Entity do
                                                    attack: Attack.new), 1)])
       entity.equip_item("Weapon")
       expect(entity.outfit[:weapon]).to eq Weapon.new
-      expect(entity.attack).to eq 4
+      expect(entity.stats[:attack]).to eq 4
       expect(entity.battle_commands).to eq [Attack.new]
     end
 
@@ -237,7 +240,7 @@ RSpec.describe Entity do
                                         Helmet.new(stat_change: { defense: 3 } ), 1)])
       entity.equip_item("Helmet")
       expect(entity.outfit[:helmet]).to eq Helmet.new
-      expect(entity.defense).to eq 4
+      expect(entity.stats[:defense]).to eq 4
     end
 
     it "correctly equips the shield and alters the stats" do
@@ -246,8 +249,8 @@ RSpec.describe Entity do
                                                                   agility: 2 } ), 1)])
       entity.equip_item("Shield")
       expect(entity.outfit[:shield]).to eq Shield.new
-      expect(entity.defense).to eq 4
-      expect(entity.agility).to eq 3
+      expect(entity.stats[:defense]).to eq 4
+      expect(entity.stats[:agility]).to eq 3
     end
 
     it "correctly equips the legs and alters the stats" do
@@ -255,7 +258,7 @@ RSpec.describe Entity do
                                         Legs.new(stat_change: { defense: 3 } ), 1)])
       entity.equip_item("Legs")
       expect(entity.outfit[:legs]).to eq Legs.new
-      expect(entity.defense).to eq 4
+      expect(entity.stats[:defense]).to eq 4
     end
 
     it "correctly equips the torso and alters the stats" do
@@ -263,7 +266,7 @@ RSpec.describe Entity do
                                         Torso.new(stat_change: { defense: 3 } ), 1)])
       entity.equip_item("Torso")
       expect(entity.outfit[:torso]).to eq Torso.new
-      expect(entity.defense).to eq 4
+      expect(entity.stats[:defense]).to eq 4
     end
 
     it "does not equip anything for an absent item" do
@@ -295,18 +298,19 @@ RSpec.describe Entity do
                                                                   agility: 7 },
                                                    attack: Attack.new(name: "Stab")), 1)])
       entity.equip_item("Hammer")
-      expect(entity.attack).to eq 4
-      expect(entity.defense).to eq 3
-      expect(entity.agility).to eq 5
+      stats = entity.stats
+      expect(stats[:attack]).to eq 4
+      expect(stats[:defense]).to eq 3
+      expect(stats[:agility]).to eq 5
       expect(entity.outfit[:weapon].name).to eq "Hammer"
       expect(entity.battle_commands).to eq [Attack.new(name: "Bash")]
       expect(entity.inventory.length).to eq 1
       expect(entity.inventory[0].first.name).to eq "Knife"
 
       entity.equip_item("Knife")
-      expect(entity.attack).to eq 6
-      expect(entity.defense).to eq 4
-      expect(entity.agility).to eq 8
+      expect(stats[:attack]).to eq 6
+      expect(stats[:defense]).to eq 4
+      expect(stats[:agility]).to eq 8
       expect(entity.outfit[:weapon].name).to eq "Knife"
       expect(entity.battle_commands).to eq [Attack.new(name: "Stab")]
       expect(entity.inventory.length).to eq 1
@@ -426,8 +430,11 @@ RSpec.describe Entity do
 
   context "print status" do
     it "prints all of the entity's information" do
-      entity = Entity.new(max_hp: 50, hp: 30, attack: 5,
-                          defense: 3, agility: 4,
+      entity = Entity.new(stats: { max_hp: 50,
+                                   hp: 30,
+                                   attack: 5,
+                                   defense: 3,
+                                   agility: 4 },
                           outfit: { helmet: Helmet.new,
                                     legs: Legs.new,
                                     shield: Shield.new,
@@ -541,7 +548,7 @@ RSpec.describe Entity do
       expect(entity.inventory[0].first).to eq Weapon.new
       expect(entity.inventory[0].second).to eq 1
       expect(entity.battle_commands).to be_empty
-      expect(entity.agility).to eq 1
+      expect(entity.stats[:agility]).to eq 1
     end
 
     it "does not result in error when unequipping the same item twice" do
@@ -562,19 +569,19 @@ RSpec.describe Entity do
 
   context "use item" do
     it "correctly uses a present item for an object argument" do
-      entity = Entity.new(max_hp: 20, hp: 10,
+      entity = Entity.new(stats: { max_hp: 20, hp: 10 },
                           inventory: [Couple.new(Food.new(recovers: 5), 3)])
       entity.use_item(Food.new, entity)
-      expect(entity.hp).to eq 15
+      expect(entity.stats[:hp]).to eq 15
       expect(entity.inventory[0].first).to eq Food.new
       expect(entity.inventory[0].second).to eq 2
     end
 
     it "correctly uses a present item for a string argument" do
-      entity = Entity.new(max_hp: 20, hp: 10,
+      entity = Entity.new(stats: { max_hp: 20, hp: 10 },
                           inventory: [Couple.new(Food.new(recovers: 5), 3)])
       entity.use_item("Food", entity)
-      expect(entity.hp).to eq 15
+      expect(entity.stats[:hp]).to eq 15
       expect(entity.inventory[0].first).to eq Food.new
       expect(entity.inventory[0].second).to eq 2
     end

--- a/spec/goby/entity/entity_spec.rb
+++ b/spec/goby/entity/entity_spec.rb
@@ -629,20 +629,20 @@ RSpec.describe Entity do
       expect(stats[:agility]).to eq 4
     end
 
-    it "does not allow hp to be above max_hp and sets to the greater of the two" do
-      entity = Entity.new
-
-      entity.set_stats({ max_hp: 2, hp: 3 })
-
-      stats = entity.stats
-      expect(stats[:max_hp]).to eq 3
-      expect(stats[:hp]).to eq 3
-    end
-
     it "sets hp to max_hp if hp is passed in as nil" do
       entity = Entity.new
 
       entity.set_stats({ max_hp: 2, hp: nil })
+
+      stats = entity.stats
+      expect(stats[:max_hp]).to eq 2
+      expect(stats[:hp]).to eq 2
+    end
+
+    it "hp cannot be more than max hp" do
+      entity = Entity.new
+
+      entity.set_stats({ max_hp: 2, hp: 3 })
 
       stats = entity.stats
       expect(stats[:max_hp]).to eq 2

--- a/spec/goby/entity/entity_spec.rb
+++ b/spec/goby/entity/entity_spec.rb
@@ -670,13 +670,11 @@ RSpec.describe Entity do
       expect(stats[:hp]).to eq 0
     end
 
-    it "prints error if non numberic values passed in" do
+    it "raises error if non-numeric passed in" do
       entity = Entity.new(stats: { attack: 11 })
-      allow(entity).to receive(:print)
 
-      entity.set_stats({ attack: "foo" })
+      expect{ entity.set_stats({ attack: "foo" }) }.to raise_error
 
-      expect(entity).to have_received(:print).with(Entity::SET_STATS_ERROR)
       expect(entity.stats[:attack]).to eq 11
     end
 

--- a/spec/goby/entity/entity_spec.rb
+++ b/spec/goby/entity/entity_spec.rb
@@ -308,6 +308,7 @@ RSpec.describe Entity do
       expect(entity.inventory[0].first.name).to eq "Knife"
 
       entity.equip_item("Knife")
+      stats = entity.stats
       expect(stats[:attack]).to eq 6
       expect(stats[:defense]).to eq 4
       expect(stats[:agility]).to eq 8
@@ -598,6 +599,99 @@ RSpec.describe Entity do
       bob = Entity.new(name: "Bob")
       marge = Entity.new(name: "Marge")
       expect(bob).not_to eq marge
+    end
+  end
+
+  context "set stats" do
+    it "changes an entities stats" do
+      entity = Entity.new(stats: { max_hp: 2, hp: 1, attack: 1, defense: 1, agility: 1 })
+
+      entity.set_stats({ max_hp: 3, hp: 3, attack: 2, defense: 3, agility: 4 })
+
+      stats = entity.stats
+      expect(stats[:max_hp]).to eq 3
+      expect(stats[:hp]).to eq 3
+      expect(stats[:attack]).to eq 2
+      expect(stats[:defense]).to eq 3
+      expect(stats[:agility]).to eq 4
+    end
+
+    it "only changes specified stats" do
+      entity = Entity.new(stats: { max_hp: 2, hp: 2, attack: 1, defense: 4, agility: 4 })
+
+      entity.set_stats({ attack: 2 })
+
+      stats = entity.stats
+      expect(stats[:max_hp]).to eq 2
+      expect(stats[:hp]).to eq 2
+      expect(stats[:attack]).to eq 2
+      expect(stats[:defense]).to eq 4
+      expect(stats[:agility]).to eq 4
+    end
+
+    it "does not allow hp to be above max_hp and sets to the greater of the two" do
+      entity = Entity.new
+
+      entity.set_stats({ max_hp: 2, hp: 3 })
+
+      stats = entity.stats
+      expect(stats[:max_hp]).to eq 3
+      expect(stats[:hp]).to eq 3
+    end
+
+    it "sets hp to max_hp if hp is passed in as nil" do
+      entity = Entity.new
+
+      entity.set_stats({ max_hp: 2, hp: nil })
+
+      stats = entity.stats
+      expect(stats[:max_hp]).to eq 2
+      expect(stats[:hp]).to eq 2
+    end
+
+    it "non hp values cannot go below 1" do
+      entity = Entity.new(stats: { max_hp: 2, attack: 1, defense: 1, agility: 1 })
+
+      entity.set_stats({ max_hp: -1, hp: -1, attack: -1, defense: -1, agility: -1 })
+
+      stats = entity.stats
+      expect(stats[:max_hp]).to eq 1
+      expect(stats[:attack]).to eq 1
+      expect(stats[:defense]).to eq 1
+      expect(stats[:agility]).to eq 1
+    end
+
+    it "hp cannot go below 0" do
+      entity = Entity.new(stats: {hp: 3})
+
+      entity.set_stats({hp: -1})
+
+      stats = entity.stats
+      expect(stats[:hp]).to eq 0
+    end
+
+    it "prints error if non numberic values passed in" do
+      entity = Entity.new(stats: { attack: 11 })
+      allow(entity).to receive(:print)
+
+      entity.set_stats({ attack: "foo" })
+
+      expect(entity).to have_received(:print).with(Entity::SET_STATS_ERROR)
+      expect(entity.stats[:attack]).to eq 11
+    end
+
+    it "only allows stats to be changed by calling set_stats" do
+      entity = Entity.new(stats: { attack: 11 })
+
+      expect do
+        entity.stats = {attack: 9}
+      end.to raise_exception
+
+      expect do
+        entity.stats[:attack] = 9
+      end.to raise_exception
+
+      expect(entity.stats[:attack]).to eq 11
     end
   end
 

--- a/spec/goby/entity/monster_spec.rb
+++ b/spec/goby/entity/monster_spec.rb
@@ -5,11 +5,11 @@ RSpec.describe Monster do
     it "has the correct default parameters" do
       monster = Monster.new
       expect(monster.name).to eq "Monster"
-      expect(monster.max_hp).to eq 1
-      expect(monster.hp).to eq 1
-      expect(monster.attack). to eq 1
-      expect(monster.defense).to eq 1
-      expect(monster.agility).to eq 1
+      expect(monster.stats[:max_hp]).to eq 1
+      expect(monster.stats[:hp]).to eq 1
+      expect(monster.stats[:attack]). to eq 1
+      expect(monster.stats[:defense]).to eq 1
+      expect(monster.stats[:agility]).to eq 1
       expect(monster.inventory).to eq Array.new
       expect(monster.gold).to eq 0
       expect(monster.outfit).to eq Hash.new
@@ -20,11 +20,11 @@ RSpec.describe Monster do
 
     it "correctly assigns custom parameters" do
       clown = Monster.new(name: "Clown",
-                        max_hp: 20,
-                        hp: 15,
-                        attack: 2,
-                        defense: 2,
-                        agility: 4,
+                          stats: { max_hp: 20,
+                                   hp: 15,
+                                   attack: 2,
+                                   defense: 2,
+                                   agility: 4 },
                         inventory: [Couple.new(Item.new, 1)],
                         gold: 10,
                         outfit: { weapon: Weapon.new(
@@ -43,11 +43,11 @@ RSpec.describe Monster do
                         treasures: [Couple.new(Item.new, 1),
                                     Couple.new(nil, 3)])
       expect(clown.name).to eq "Clown"
-      expect(clown.max_hp).to eq 20
-      expect(clown.hp).to eq 15
-      expect(clown.attack).to eq 6
-      expect(clown.defense).to eq 8
-      expect(clown.agility).to eq 4
+      expect(clown.stats[:max_hp]).to eq 20
+      expect(clown.stats[:hp]).to eq 15
+      expect(clown.stats[:attack]).to eq 6
+      expect(clown.stats[:defense]).to eq 8
+      expect(clown.stats[:agility]).to eq 4
       expect(clown.inventory).to eq [Couple.new(Item.new, 1)]
       expect(clown.gold).to eq 10
       expect(clown.outfit[:weapon]).to eq Weapon.new

--- a/spec/goby/entity/player_spec.rb
+++ b/spec/goby/entity/player_spec.rb
@@ -16,14 +16,14 @@ RSpec.describe Player do
   end
 
   before(:each) do
-    @dude = Player.new(attack: 10, agility: 10000,
+    @dude = Player.new(stats: { attack: 10, agility: 10000 },
                        battle_commands: [Attack.new(strength: 20), Escape.new, Use.new],
                        map: @map, location: @center)
     @slime = Monster.new(battle_commands: [Attack.new(success_rate: 0)],
                          gold: 5000, treasures: [Couple.new(Item.new, 1)])
     @newb = Player.new(battle_commands: [Attack.new(success_rate: 0)],
                        gold: 50, map: @map, location: @center)
-    @dragon = Monster.new(attack: 50, agility: 10000,
+    @dragon = Monster.new(stats: { attack: 50, agility: 10000 },
                           battle_commands: [Attack.new(strength: 50)] )
   end
 
@@ -31,11 +31,11 @@ RSpec.describe Player do
     it "has the correct default parameters" do
       player = Player.new
       expect(player.name).to eq "Player"
-      expect(player.max_hp).to eq 1
-      expect(player.hp).to eq 1
-      expect(player.attack). to eq 1
-      expect(player.defense).to eq 1
-      expect(player.agility).to eq 1
+      expect(player.stats[:max_hp]).to eq 1
+      expect(player.stats[:hp]).to eq 1
+      expect(player.stats[:attack]). to eq 1
+      expect(player.stats[:defense]).to eq 1
+      expect(player.stats[:agility]).to eq 1
       expect(player.inventory).to eq Array.new
       expect(player.gold).to eq 0
       expect(player.outfit).to eq Hash.new
@@ -46,11 +46,11 @@ RSpec.describe Player do
 
     it "correctly assigns custom parameters" do
       hero = Player.new(name: "Hero",
-                        max_hp: 50,
-                        hp: 35,
-                        attack: 12,
-                        defense: 4,
-                        agility: 9,
+                        stats: { max_hp: 50,
+                                 hp: 35,
+                                 attack: 12,
+                                 defense: 4,
+                                 agility: 9 },
                         inventory: [Couple.new(Item.new, 1)],
                         gold: 10,
                         outfit: { weapon: Weapon.new(
@@ -65,11 +65,11 @@ RSpec.describe Player do
                         map: @map,
                         location: Couple.new(1,1))
       expect(hero.name).to eq "Hero"
-      expect(hero.max_hp).to eq 50
-      expect(hero.hp).to eq 35
-      expect(hero.attack).to eq 16
-      expect(hero.defense).to eq 10
-      expect(hero.agility).to eq 9
+      expect(hero.stats[:max_hp]).to eq 50
+      expect(hero.stats[:hp]).to eq 35
+      expect(hero.stats[:attack]).to eq 16
+      expect(hero.stats[:defense]).to eq 10
+      expect(hero.stats[:agility]).to eq 9
       expect(hero.inventory).to eq [Couple.new(Item.new, 1)]
       expect(hero.gold).to eq 10
       expect(hero.outfit[:weapon]).to eq Weapon.new
@@ -178,9 +178,9 @@ RSpec.describe Player do
     end
 
     it "recovers the player's HP to max" do
-      @dude.hp = 0
+      @dude.stats[:hp] = 0
       @dude.die
-      expect(@dude.hp).to eq @dude.max_hp
+      expect(@dude.stats[:hp]).to eq @dude.stats[:max_hp]
     end
   end
 

--- a/spec/goby/entity/player_spec.rb
+++ b/spec/goby/entity/player_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe Player do
     end
 
     it "recovers the player's HP to max" do
-      @dude.stats[:hp] = 0
+      @dude.set_stats(hp: 0)
       @dude.die
       expect(@dude.stats[:hp]).to eq @dude.stats[:max_hp]
     end

--- a/spec/goby/item/equippable_spec.rb
+++ b/spec/goby/item/equippable_spec.rb
@@ -56,17 +56,10 @@ RSpec.describe Equippable do
       expect(@entity.stats[:hp]).to eq 1
     end
 
-    it "does not kill an entity by unequipping" do
-      @entity.set_stats({ hp: 3, max_hp: 5 })
-      initial_stat_stub = { max_hp: 4 }
-      altered_stat_stub = { max_hp: 4, hp: 4 }
-      allow(initial_stat_stub).to receive(:[]=)
-      allow(@equippable).to receive(:stat_change).and_return(initial_stat_stub,
-                                                             initial_stat_stub,
-                                                             altered_stat_stub)
-
+    it "automatically decreases hp to match max_hp" do
+      @entity.set_stats({ max_hp: 3, hp: 2 })
       @equippable.alter_stats(@entity, false)
-      expect(initial_stat_stub).to have_received(:[]=).with(:hp, 4)
+      expect(@entity.stats[:max_hp]).to eq 1
       expect(@entity.stats[:hp]).to eq 1
     end
   end

--- a/spec/goby/item/equippable_spec.rb
+++ b/spec/goby/item/equippable_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe Equippable do
     end
 
     it "forces :stat_change to be implemented" do
-      expect {@equippable.stat_change}.to raise_error(NotImplementedError, 'An Equippable Item must implement a stat_change Hash')
+      expect { @equippable.stat_change }.to raise_error(NotImplementedError, 'An Equippable Item must implement a stat_change Hash')
     end
 
     it "forces :type to be implemented" do
-      expect {@equippable.type}. to raise_error(NotImplementedError, 'An Equippable Item must have a type')
+      expect { @equippable.type }.to raise_error(NotImplementedError, 'An Equippable Item must have a type')
     end
   end
 
@@ -53,6 +53,20 @@ RSpec.describe Equippable do
       expect(@entity.stats[:defense]).to eq 1
       expect(@entity.stats[:agility]).to eq 1
       expect(@entity.stats[:max_hp]).to eq 1
+      expect(@entity.stats[:hp]).to eq 1
+    end
+
+    it "does not kill an entity by unequipping" do
+      @entity.set_stats({ hp: 3, max_hp: 5 })
+      initial_stat_stub = { max_hp: 4 }
+      altered_stat_stub = { max_hp: 4, hp: 4 }
+      allow(initial_stat_stub).to receive(:[]=)
+      allow(@equippable).to receive(:stat_change).and_return(initial_stat_stub,
+                                                             initial_stat_stub,
+                                                             altered_stat_stub)
+
+      @equippable.alter_stats(@entity, false)
+      expect(initial_stat_stub).to have_received(:[]=).with(:hp, 4)
       expect(@entity.stats[:hp]).to eq 1
     end
   end

--- a/spec/goby/item/equippable_spec.rb
+++ b/spec/goby/item/equippable_spec.rb
@@ -2,15 +2,15 @@ require 'goby'
 
 RSpec.describe Equippable do
 
-  before (:all) do
-    @equippable = double
-    class << @equippable
-      include Equippable
-    end
-    @entity = Entity.new
-  end
-
   context "placeholder methods" do
+
+    before (:all) do
+      @equippable = double
+      class << @equippable
+        include Equippable
+      end
+    end
+
     it "forces :stat_change to be implemented" do
       expect {@equippable.stat_change}.to raise_error(NotImplementedError, 'An Equippable Item must implement a stat_change Hash')
     end
@@ -21,18 +21,39 @@ RSpec.describe Equippable do
   end
 
   context "alter stats" do
-    it "changes the entity's stats in the trivial case" do
-      allow(@equippable).to receive(:stat_change) {{attack: 2, defense: 3, agility: 4}}
 
+    before (:each) do
+      @equippable = double
+      class << @equippable
+        include Equippable
+      end
+      @entity = Entity.new
+      allow(@equippable).to receive(:stat_change) { { attack: 2, defense: 3, agility: 4, max_hp: 2 } }
+    end
+
+    it "changes the entity's stats in the trivial case" do
       @equippable.alter_stats(@entity, true)
       expect(@entity.stats[:attack]).to eq 3
       expect(@entity.stats[:defense]).to eq 4
       expect(@entity.stats[:agility]).to eq 5
+      expect(@entity.stats[:max_hp]).to eq 3
+      expect(@entity.stats[:hp]).to eq 1
 
       @equippable.alter_stats(@entity, false)
       expect(@entity.stats[:attack]).to eq 1
       expect(@entity.stats[:defense]).to eq 1
       expect(@entity.stats[:agility]).to eq 1
+      expect(@entity.stats[:max_hp]).to eq 1
+      expect(@entity.stats[:hp]).to eq 1
+    end
+
+    it "does not lower stats below 1" do
+      @equippable.alter_stats(@entity, false)
+      expect(@entity.stats[:attack]).to eq 1
+      expect(@entity.stats[:defense]).to eq 1
+      expect(@entity.stats[:agility]).to eq 1
+      expect(@entity.stats[:max_hp]).to eq 1
+      expect(@entity.stats[:hp]).to eq 1
     end
   end
 

--- a/spec/goby/item/equippable_spec.rb
+++ b/spec/goby/item/equippable_spec.rb
@@ -25,14 +25,14 @@ RSpec.describe Equippable do
       allow(@equippable).to receive(:stat_change) {{attack: 2, defense: 3, agility: 4}}
 
       @equippable.alter_stats(@entity, true)
-      expect(@entity.attack).to eq 3
-      expect(@entity.defense).to eq 4
-      expect(@entity.agility).to eq 5
+      expect(@entity.stats[:attack]).to eq 3
+      expect(@entity.stats[:defense]).to eq 4
+      expect(@entity.stats[:agility]).to eq 5
 
       @equippable.alter_stats(@entity, false)
-      expect(@entity.attack).to eq 1
-      expect(@entity.defense).to eq 1
-      expect(@entity.agility).to eq 1
+      expect(@entity.stats[:attack]).to eq 1
+      expect(@entity.stats[:defense]).to eq 1
+      expect(@entity.stats[:agility]).to eq 1
     end
   end
 

--- a/spec/goby/item/food_spec.rb
+++ b/spec/goby/item/food_spec.rb
@@ -29,23 +29,24 @@ RSpec.describe Food do
 
   context "use" do
     it "heals the entity's HP in a trivial case" do
-      entity = Entity.new(hp: 5, max_hp: 20)
+      entity = Entity.new(stats: { hp: 5, max_hp: 20 })
       @magic_banana.use(entity, entity)
-      expect(entity.hp).to eq 15
+      expect(entity.stats[:hp]).to eq 15
     end
 
     it "does not heal over the entity's max HP" do
-      entity = Entity.new(hp: 15, max_hp: 20)
+      entity = Entity.new(stats: { hp: 15, max_hp: 20 })
       @magic_banana.use(entity, entity)
-      expect(entity.hp).to eq 20
+      expect(entity.stats[:hp]).to eq 20
     end
   end
 
   it "heals another entity's HP as appropriate" do
     bob = Entity.new(name: "Bob")
-    marge = Entity.new(name: "Marge", hp: 5, max_hp: 20)
+    marge = Entity.new(name: "Marge",
+                       stats: { hp: 5, max_hp: 20 })
     @magic_banana.use(bob, marge)
-    expect(marge.hp).to eq 15
+    expect(marge.stats[:hp]).to eq 15
   end
 
 end

--- a/spec/goby/util_spec.rb
+++ b/spec/goby/util_spec.rb
@@ -90,12 +90,13 @@ RSpec.describe do
 
   context "load game" do
     it "should load the player's information" do
-      player1 = Player.new(name: "Nicholas", max_hp: 5, hp: 3)
+      player1 = Player.new(name: "Nicholas",
+                           stats: { max_hp: 5, hp: 3 })
       save_game(player1, "test.yaml")
       player2 = load_game("test.yaml")
       expect(player2.name).to eq "Nicholas"
-      expect(player2.max_hp).to eq 5
-      expect(player2.hp).to eq 3
+      expect(player2.stats[:max_hp]).to eq 5
+      expect(player2.stats[:hp]).to eq 3
       File.delete("test.yaml")
     end
 

--- a/spec/goby/world_command_spec.rb
+++ b/spec/goby/world_command_spec.rb
@@ -12,8 +12,7 @@ RSpec.describe do
                               Tile.new(events: [Event.new(visible: false), Shop.new, NPC.new]) ] ],
                       regen_location: Couple.new(0,0))
 
-    @player = Player.new(max_hp: 10,
-                         hp: 3,
+    @player = Player.new(stats: { max_hp: 10, hp: 3 },
                          inventory: [ Couple.new(Food.new(name: "Banana", recovers: 5), 1),
                                       Couple.new(Food.new(name: "Onion", disposable: false), 1),
                                       Couple.new(Item.new(name: "Big Book of Stuff"), 1),
@@ -159,7 +158,7 @@ RSpec.describe do
       it "should use the specified item" do
         interpret_command("use banana", @player)
         expect(@player.has_item("Banana")).to be_nil
-        expect(@player.hp).to eq 8
+        expect(@player.stats[:hp]).to eq 8
       end
 
       it "should print error text for using nonexistent item" do


### PR DESCRIPTION
I think it might be worth putting the stats into their own class after doing this. Seeing entity.stats.hp seems cleaner to me than entity.stats[:hp]. Let me know what you think about that.

 Also I could be talked out of my alter_stats implementation for something more readable like;

```
def alter_stats(entity, equipping)

      # Alter the stats as appropriate.
      stats = entity.stats
      equipment_stats = [:attack, :defense, :agility]
      if equipping
        equipment_stats.each {|stat| stats[stat] += stat_change[stat] if stat_change[stat]}
      else
        equipment_stats.each {|stat| stats[stat] -= stat_change[stat] if stat_change[stat]}
      end

    end
```