### PR TITLE
Add i18n support

### DIFF
--- a/goby.gemspec
+++ b/goby.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "i18n", "~> 0.8"
+
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/lib/goby.rb
+++ b/lib/goby.rb
@@ -6,6 +6,9 @@ end
 
 # Import order matters.
 
+require 'i18n'
+I18n.load_path = Dir["#{File.expand_path(File.dirname(__FILE__))}/goby/config/locales/*.yml"]
+
 require 'goby/extension'
 require 'goby/util'
 require 'goby/world_command'

--- a/lib/goby/config/locales/en.yml
+++ b/lib/goby/config/locales/en.yml
@@ -1,0 +1,6 @@
+en:
+  goby:
+    entity:
+      errors:
+        no_such_item: "What?! You don't have THAT!"
+        item_not_equipped: "You are not equipping THAT!"

--- a/lib/goby/entity/entity.rb
+++ b/lib/goby/entity/entity.rb
@@ -7,9 +7,9 @@ module Goby
   class Entity
 
     # Error when the entity specifies a non-existent item.
-    NO_SUCH_ITEM_ERROR = "What?! You don't have THAT!\n\n"
+    NO_SUCH_ITEM_ERROR = I18n.t('goby.entity.errors.no_such_item')
     # Error when the entity specifies an item not equipped.
-    NOT_EQUIPPED_ERROR = "You are not equipping THAT!\n\n"
+    NOT_EQUIPPED_ERROR = I18n.t('goby.entity.errors.item_not_equipped')
 
     # @param [String] name the name.
     # @param [Hash] stats hash of stats


### PR DESCRIPTION
# Pull Request Description
This PR adds internationalization support via I18n, by:
- Adding i18n as a dependency
- Adding 'lib/goby/config/locales' directory (where I18n will load translations from by default)
- Adding a basic `en.yml` to be updated as required
- Placing an example on how to set translations in `Entity` class

# Documentation proposal

## Updating Goby messages

### As a Goby contributor

#### Customizing and exiting language translations:
1. Edit the corresponding file under `config/locales`

#### Adding support for new language:
1. Add a new file for the new language to be supported under `config/locales`
1. Copy `config/locales/en.yml` content and update as required

### As an application developer using Goby gem

#### Customizing and exiting language translations:
1. Add a custom directory to I18n translation lookup:
```I18n.load_path += Dir["#{File.expand_path File.dirname(__FILE__)}/.../*.yml"]```
2. Copy the corresponding file into that directory and update as required

#### Adding support for new language:
1. Add a custom directory to I18n translation lookup:
```I18n.load_path += Dir["#{File.expand_path File.dirname(__FILE__)}/.../*.yml"]```
2. Create a file with the supporting the language, such as: 
```
# .../locales/es.yml
es:
  ...
    no_such_item: ...
```
3. Copy default `en.yml` content from Goby into that file and update as required
4. Set the locale: `I18n.locale = :es`

Finally, I think it would be wise (and actually make other developers life easier) if we place a link to the `en.yml` in the documentation. By doing this, they would be able to get to that file without having to browse through all the repository.