### PR TITLE
Generate minimal scaffolding (Resolves #109)

### DIFF
--- a/exe/goby
+++ b/exe/goby
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
 
 require 'goby'
-Goby::Scaffold::simple
+Goby::Scaffold::simple "goby-project"

--- a/exe/goby
+++ b/exe/goby
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+
+require 'goby'
+Goby::Scaffold::simple

--- a/goby.gemspec
+++ b/goby.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/nskins/goby"
   spec.license       = "MIT"
 
-  spec.files = Dir["{lib}/**/*", "LICENSE", "README.md" ]
+  spec.files = Dir["{exe}/**/*", "{lib}/**/*", "{res}/**/*", "LICENSE", "README.md" ]
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]

--- a/lib/goby.rb
+++ b/lib/goby.rb
@@ -1,5 +1,6 @@
 # Import order matters.
 
+require 'goby/scaffold'
 require 'goby/extension'
 require 'goby/util'
 require 'goby/world_command'

--- a/lib/goby/scaffold.rb
+++ b/lib/goby/scaffold.rb
@@ -4,15 +4,18 @@ module Goby
   module Scaffold
 
     # Simple starter project w/o testing.
-    def self.simple
+    #
+    # @param [String] project the project name.
+    def self.simple(project)
 
-      # TODO: detect existence of src folder.
+      # TODO: detect existence of project folder.
 
       # Make the directory structure.
+      Dir.mkdir project
       dirs = [ '', 'battle', 'entity',
                'event', 'item', 'map' ]
       dirs.each do |dir|
-        Dir.mkdir "src/#{dir}"
+        Dir.mkdir "#{project}/src/#{dir}"
       end
 
       # Create the source files.
@@ -20,7 +23,7 @@ module Goby
       files = { '.gitignore': '../gitignore',
                 'src/main.rb': 'main.rb' }
       files.each do |dest, source|
-        File.open(dest.to_s, 'w') do |w|
+        File.open("#{project}/#{dest.to_s}", 'w') do |w|
           w.write(File.read "#{gem_location}/res/scaffold/simple/#{source}")
         end
       end

--- a/lib/goby/scaffold.rb
+++ b/lib/goby/scaffold.rb
@@ -21,7 +21,8 @@ module Goby
       # Create the source files.
       gem_location = %x[gem which goby].chomp "/lib/goby.rb\n"
       files = { '.gitignore': '../gitignore',
-                'src/main.rb': 'main.rb' }
+                'src/main.rb': 'main.rb',
+                'src/map/farm.rb': 'farm.rb' }
       files.each do |dest, source|
         File.open("#{project}/#{dest.to_s}", 'w') do |w|
           w.write(File.read "#{gem_location}/res/scaffold/simple/#{source}")

--- a/lib/goby/scaffold.rb
+++ b/lib/goby/scaffold.rb
@@ -1,0 +1,32 @@
+module Goby
+
+  # Functions for scaffolding starter projects.
+  module Scaffold
+
+    # Simple starter project w/o testing.
+    def self.simple
+
+      # TODO: detect existence of src folder.
+
+      # Make the directory structure.
+      dirs = [ '', 'battle', 'entity',
+               'event', 'item', 'map' ]
+      dirs.each do |dir|
+        Dir.mkdir "src/#{dir}"
+      end
+
+      # Create the source files.
+      gem_location = %x[gem which goby].chomp "/lib/goby.rb\n"
+      files = { '.gitignore': '../gitignore',
+                'src/main.rb': 'main.rb' }
+      files.each do |dest, source|
+        File.open(dest.to_s, 'w') do |w|
+          w.write(File.read "#{gem_location}/res/scaffold/simple/#{source}")
+        end
+      end
+
+    end
+
+  end
+
+end

--- a/res/scaffold/gitignore
+++ b/res/scaffold/gitignore
@@ -1,0 +1,50 @@
+*.gem
+*.rbc
+/.config
+/coverage/
+/InstalledFiles
+/pkg/
+/spec/reports/
+/spec/examples.txt
+/test/tmp/
+/test/version_tmp/
+/tmp/
+
+# Used by dotenv library to load environment variables.
+# .env
+
+## Specific to RubyMotion:
+.dat*
+.repl_history
+build/
+*.bridgesupport
+build-iPhoneOS/
+build-iPhoneSimulator/
+
+## Specific to RubyMotion (use of CocoaPods):
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+# vendor/Pods/
+
+## Documentation cache and generated files:
+/.yardoc/
+/_yardoc/
+/doc/
+/rdoc/
+
+## Environment normalization:
+/.bundle/
+/vendor/bundle
+/lib/bundler/man/
+
+# for a library or gem, you might want to ignore these files since the code is
+# intended to run in multiple environments; otherwise, check them in:
+# Gemfile.lock
+# .ruby-version
+# .ruby-gemset
+
+# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
+.rvmrc

--- a/res/scaffold/simple/farm.rb
+++ b/res/scaffold/simple/farm.rb
@@ -1,0 +1,14 @@
+# This is an example of how to create a Map. You can
+# define the name, where to respawn, and
+class Farm < Map
+  def initialize
+    super(name: "Farm", regen_location: Couple.new(2,2))
+
+    # Define the main tiles on this map.
+    grass = Tile.new
+
+    # Fill the map with grass.
+    @tiles = Array.new(5) { Array.new(5) { grass.clone } }
+
+  end
+end

--- a/res/scaffold/simple/farm.rb
+++ b/res/scaffold/simple/farm.rb
@@ -1,13 +1,14 @@
 # This is an example of how to create a Map. You can
-# define the name, where to respawn, and
+# define the name, where to respawn, and the 2D display of
+# the Map - each point is referred to as a Tile.
 class Farm < Map
   def initialize
     super(name: "Farm", regen_location: Couple.new(2,2))
 
     # Define the main tiles on this map.
-    grass = Tile.new
+    grass = Tile.new(description: "You are standing on some grass.")
 
-    # Fill the map with grass.
+    # Fill the map with "grass."
     @tiles = Array.new(5) { Array.new(5) { grass.clone } }
 
   end

--- a/res/scaffold/simple/main.rb
+++ b/res/scaffold/simple/main.rb
@@ -1,20 +1,17 @@
 require 'goby'
-require 'optparse'
 
 include Goby
 
 require_relative 'map/farm.rb'
 
-# Command-line arguments.
-options = {}
-OptionParser.new do |opts|
-  # Specify whether or not to play background music.
-  opts.on("-m", "--[no-]music", "Run music") do |v|
-    options[:music] = v
-    Music::set_playback(v)
-  end
-end.parse!
+# Set this to true in order to use BGM.
+Music::set_playback(false)
 
+# By default, we've included no music files.
+# The Music module also includes a function
+# to change the music-playing program.
+
+# Clear the terminal.
 system("clear")
 
 # Allow the player to load an existing game.

--- a/res/scaffold/simple/main.rb
+++ b/res/scaffold/simple/main.rb
@@ -1,0 +1,37 @@
+require 'goby'
+require 'optparse'
+include Goby
+
+# Command-line arguments.
+options = {}
+OptionParser.new do |opts|
+  # Specify whether or not to play background music.
+  opts.on("-m", "--[no-]music", "Run music") do |v|
+    options[:music] = v
+    Music::set_playback(v)
+  end
+end.parse!
+
+system("clear")
+
+# Allow the player to load an existing game.
+if File.exists?("player.yaml")
+  print "Load the saved file?: "
+  input = player_input
+  if input.is_positive?
+    player = load_game("player.yaml")
+    describe_tile(player)
+  end
+end
+
+# No load? Create a new player.
+if player.nil?
+
+  # Use the Player constructor to set the
+  # initial Map, (y,x) location, stats,
+  # gold, inventory, and more.
+  player = Player.new(gold: 1)
+
+end
+
+run_driver(player)

--- a/res/scaffold/simple/main.rb
+++ b/res/scaffold/simple/main.rb
@@ -1,6 +1,9 @@
 require 'goby'
 require 'optparse'
+
 include Goby
+
+require_relative 'map/farm.rb'
 
 # Command-line arguments.
 options = {}
@@ -30,7 +33,7 @@ if player.nil?
   # Use the Player constructor to set the
   # initial Map, (y,x) location, stats,
   # gold, inventory, and more.
-  player = Player.new(gold: 1)
+  player = Player.new(map: Farm.new, location: Couple.new(2,2))
 
 end
 

--- a/spec/goby/scaffold_spec.rb
+++ b/spec/goby/scaffold_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Scaffold do
       end
 
       # Ensure all of the files exist.
-      [ '.gitignore', 'src/main.rb' ].each do |file|
+      [ '.gitignore', 'src/main.rb', 'src/map/farm.rb' ].each do |file|
         expect(File.exist? "#{project}/#{file}").to be true
       end
 

--- a/spec/goby/scaffold_spec.rb
+++ b/spec/goby/scaffold_spec.rb
@@ -1,0 +1,30 @@
+require 'goby'
+require 'fileutils'
+
+RSpec.describe Scaffold do
+
+  context "simple" do
+    it "should create the appropriate directories & files" do
+
+      project = "goby-project"
+      Scaffold::simple project
+
+      # Ensure all of the directories exist.
+      expect(Dir.exists? "#{project}").to be true
+      [ '', 'battle', 'entity',
+      'event', 'item', 'map' ].each do |dir|
+        expect(Dir.exist? "#{project}/src/#{dir}").to be true
+      end
+
+      # Ensure all of the files exist.
+      [ '.gitignore', 'src/main.rb' ].each do |file|
+        expect(File.exist? "#{project}/#{file}").to be true
+      end
+
+      # Clean up the scaffolding.
+      FileUtils.remove_dir project
+
+    end
+  end
+
+end


### PR DESCRIPTION
Goby now includes a simple executable that generates a very minimal starter project. A simple main function and Map are included, along with a .gitignore.

In order to try this feature, you will need to install the Goby gem. _Until the release of Goby 0.2.0, this must be done while your working directory is the source code root._

```bash
$ gem build goby
$ gem install goby
```

Find a location for your starter project and run the following command to generate the "goby-project" directory:

```bash
$ goby
```

You can run the following to "play" the starter project:

```bash
$ ruby goby-project/src/main.rb
```

Keep in mind that this is _not_ a tutorial or full-fledged example; the purpose of this feature is to provide a quick way to get up and running without the initial "plumbing." Please enjoy and let me know if you have any questions.