### PR TITLE
Respawn Location

### DIFF
--- a/lib/goby/entity/player.rb
+++ b/lib/goby/entity/player.rb
@@ -46,7 +46,7 @@ module Goby
       add_battle_commands(battle_commands)
 
       move_to(Location.new(new_map, new_coords))
-      @respawn_location = respawn_location
+      @respawn_location = respawn_location || @location
       @saved_maps = Hash.new
     end
 
@@ -123,9 +123,7 @@ module Goby
     def die
       sleep(2) unless ENV['TEST']
 
-      # TODO: No respawn location? Display 'GAME OVER' & end game.
       @location = @respawn_location
-
       type("After being knocked out in battle,\n")
       type("you wake up in #{@location.map.name}.\n\n")
 

--- a/lib/goby/entity/player.rb
+++ b/lib/goby/entity/player.rb
@@ -293,8 +293,8 @@ module Goby
       gold_lost
     end
 
-    attr_reader :location, :respawn_location, :saved_maps
-    attr_accessor :moved
+    attr_reader :location, :saved_maps
+    attr_accessor :moved, :respawn_location
 
   end
 

--- a/lib/goby/entity/player.rb
+++ b/lib/goby/entity/player.rb
@@ -123,7 +123,7 @@ module Goby
     def die
       sleep(2) unless ENV['TEST']
 
-      @location = @respawn_location
+      move_to(@respawn_location)
       type("After being knocked out in battle,\n")
       type("you wake up in #{@location.map.name}.\n\n")
 

--- a/lib/goby/entity/player.rb
+++ b/lib/goby/entity/player.rb
@@ -25,9 +25,10 @@ module Goby
     # @param [Integer] gold the currency used for economical transactions.
     # @param [[BattleCommand]] battle_commands the commands that can be used in battle.
     # @param [Hash] outfit the collection of equippable items currently worn.
-    # @param [Location] location at which the player should start.
+    # @param [Location] location the place at which the player should start.
+    # @param [Location] respawn_location the place at which the player respawns.
     def initialize(name: "Player", stats: {}, inventory: [], gold: 0, battle_commands: [],
-                   outfit: {}, location: nil)
+                   outfit: {}, location: nil, respawn_location: nil)
       super(name: name, stats: stats, inventory: inventory, gold: gold, outfit: outfit)
       @saved_maps = Hash.new
 
@@ -45,6 +46,7 @@ module Goby
       add_battle_commands(battle_commands)
 
       move_to(Location.new(new_map, new_coords))
+      @respawn_location = respawn_location
       @saved_maps = Hash.new
     end
 
@@ -293,7 +295,7 @@ module Goby
       gold_lost
     end
 
-    attr_reader :location, :saved_maps
+    attr_reader :location, :respawn_location, :saved_maps
     attr_accessor :moved
 
   end

--- a/lib/goby/entity/player.rb
+++ b/lib/goby/entity/player.rb
@@ -123,8 +123,8 @@ module Goby
     def die
       sleep(2) unless ENV['TEST']
 
-      # TODO: fix next line. regen_coords could be nil or "bad."
-      @location = Location.new(@location.map, @location.map.regen_coords)
+      # TODO: No respawn location? Display 'GAME OVER' & end game.
+      @location = @respawn_location
 
       type("After being knocked out in battle,\n")
       type("you wake up in #{@location.map.name}.\n\n")

--- a/lib/goby/map/map.rb
+++ b/lib/goby/map/map.rb
@@ -5,11 +5,9 @@ module Goby
 
     # @param [String] name the name.
     # @param [[Tile]] tiles the content of the map.
-    # @param [C(Integer, Integer)] regen_coords respawn-on-death coordinates.
-    def initialize(name: "Map", tiles: [[Tile.new]], regen_coords: C[0,0], music: nil)
+    def initialize(name: "Map", tiles: [[Tile.new]], music: nil)
       @name = name
       @tiles = tiles
-      @regen_coords = regen_coords
       @music = music
     end
 
@@ -40,7 +38,7 @@ module Goby
       return @name == rhs.name
     end
 
-    attr_accessor :name, :tiles, :regen_coords, :music
+    attr_accessor :name, :tiles, :music
 
   end
 

--- a/res/scaffold/simple/farm.rb
+++ b/res/scaffold/simple/farm.rb
@@ -3,7 +3,7 @@
 # the Map - each point is referred to as a Tile.
 class Farm < Map
   def initialize
-    super(name: "Farm", regen_coords: C[1, 1])
+    super(name: "Farm")
 
     # Define the main tiles on this map.
     grass = Tile.new(description: "You are standing on some grass.")

--- a/res/scaffold/simple/main.rb
+++ b/res/scaffold/simple/main.rb
@@ -30,7 +30,7 @@ if player.nil?
 
   # Use the Player constructor to set the
   # location, stats, gold, inventory, and more.
-  player = Player.new(location: home, respawn_location: home)
+  player = Player.new(location: home)
 
 end
 

--- a/res/scaffold/simple/main.rb
+++ b/res/scaffold/simple/main.rb
@@ -25,11 +25,12 @@ end
 
 # No load? Create a new player.
 if player.nil?
+  # A Location specifies the Map and (y,x) coordinates of a Player.
+  home = Location.new(Farm.new, C[1, 1])
 
   # Use the Player constructor to set the
-  # initial Map, (y,x) location, stats,
-  # gold, inventory, and more.
-  player = Player.new(location: Location.new(Farm.new, C[1, 1]))
+  # location, stats, gold, inventory, and more.
+  player = Player.new(location: home, respawn_location: home)
 
 end
 

--- a/spec/goby/entity/monster_spec.rb
+++ b/spec/goby/entity/monster_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Monster do
   let!(:slime) { Monster.new(battle_commands: [Attack.new(success_rate: 0)],
                              gold: 5000, treasures: [C[slime_item, 1]]) }
   let(:newb) { Player.new(battle_commands: [Attack.new(success_rate: 0)],
-                           gold: 50) }
+                           gold: 50, respawn_location: Location.new(Map.new, C[0, 0])) }
 
   context "constructor" do
     it "has the correct default parameters" do

--- a/spec/goby/entity/player_spec.rb
+++ b/spec/goby/entity/player_spec.rb
@@ -5,9 +5,8 @@ RSpec.describe Player do
   # Constructs a map in the shape of a plus sign.
   let!(:map) { Map.new(tiles: [[Tile.new(passable: false), Tile.new, Tile.new(passable: false)],
                                [Tile.new, Tile.new, Tile.new(monsters: [Monster.new(battle_commands: [Attack.new(success_rate: 0)])])],
-                               [Tile.new(passable: false), Tile.new, Tile.new(passable: false)]],
-                       regen_coords: C[1, 1]) }
-  let!(:center) { map.regen_coords }
+                               [Tile.new(passable: false), Tile.new, Tile.new(passable: false)]]) }
+  let!(:center) { C[1, 1] }
   let!(:passable) { Tile::DEFAULT_PASSABLE }
   let!(:impassable) { Tile::DEFAULT_IMPASSABLE }
 
@@ -22,8 +21,7 @@ RSpec.describe Player do
   let!(:dragon) { Monster.new(stats: {attack: 50, agility: 10000},
                               battle_commands: [Attack.new(strength: 50)]) }
   let!(:chest_map) { Map.new(name: "Chest Map",
-                             tiles: [[Tile.new(events: [Chest.new(gold: 5)]), Tile.new(events: [Chest.new(gold: 5)])]],
-                             regen_coords: C[0, 0]) }
+                             tiles: [[Tile.new(events: [Chest.new(gold: 5)]), Tile.new(events: [Chest.new(gold: 5)])]]) }
 
   context "constructor" do
     it "has the correct default parameters" do

--- a/spec/goby/entity/player_spec.rb
+++ b/spec/goby/entity/player_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe Player do
       expect(player.battle_commands).to eq Array.new
       expect(player.location.map).to eq Player::DEFAULT_MAP
       expect(player.location.coords).to eq Player::DEFAULT_COORDS
+      expect(player.respawn_location).to be_nil
     end
 
     it "correctly assigns custom parameters" do
@@ -59,7 +60,8 @@ RSpec.describe Player do
                             BattleCommand.new(name: "Yell"),
                             BattleCommand.new(name: "Run")
                         ],
-                        location: Location.new(map, C[1, 1]))
+                        location: Location.new(map, C[1, 1]),
+                        respawn_location: Location.new(map, C[1, 2]))
       expect(hero.name).to eq "Hero"
       expect(hero.stats[:max_hp]).to eq 50
       expect(hero.stats[:hp]).to eq 35
@@ -77,6 +79,8 @@ RSpec.describe Player do
                                          ]
       expect(hero.location.map).to eq map
       expect(hero.location.coords).to eq C[1, 1]
+      expect(hero.respawn_location.map).to eq map
+      expect(hero.respawn_location.coords).to eq C[1, 2]
     end
 
     context "places the player in the default map & location" do

--- a/spec/goby/entity/player_spec.rb
+++ b/spec/goby/entity/player_spec.rb
@@ -38,7 +38,8 @@ RSpec.describe Player do
       expect(player.battle_commands).to eq Array.new
       expect(player.location.map).to eq Player::DEFAULT_MAP
       expect(player.location.coords).to eq Player::DEFAULT_COORDS
-      expect(player.respawn_location).to be_nil
+      expect(player.respawn_location.map).to eq Player::DEFAULT_MAP
+      expect(player.respawn_location.coords).to eq Player::DEFAULT_COORDS
     end
 
     it "correctly assigns custom parameters" do
@@ -80,6 +81,12 @@ RSpec.describe Player do
       expect(hero.location.coords).to eq C[1, 1]
       expect(hero.respawn_location.map).to eq map
       expect(hero.respawn_location.coords).to eq C[1, 2]
+    end
+
+    it "sets respawn to start location for no respawn_location" do
+      player = Player.new(location: Location.new(map, C[1, 1]))
+      expect(player.respawn_location.map).to eq map
+      expect(player.respawn_location.coords).to eq C[1, 1]
     end
 
     context "places the player in the default map & location" do

--- a/spec/goby/entity/player_spec.rb
+++ b/spec/goby/entity/player_spec.rb
@@ -384,7 +384,7 @@ RSpec.describe Player do
   end
 
   context "die" do
-    it "moves the player back to the map's regen location" do
+    it "moves the player back to his/her respawn location" do
       newb.move_left
       expect(newb.location.coords).to eq C[1, 0]
       newb.die

--- a/spec/goby/entity/player_spec.rb
+++ b/spec/goby/entity/player_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Player do
                              gold: 5000, treasures: [C[Item.new, 1]]) }
   let!(:newb) { Player.new(battle_commands: [Attack.new(success_rate: 0)],
                            gold: 50, location: Location.new(map, center),
-                           respawn_location: Location.new(map, C[1, 2])) }
+                           respawn_location: Location.new(map, C[2, 1])) }
   let!(:dragon) { Monster.new(stats: {attack: 50, agility: 10000},
                               battle_commands: [Attack.new(strength: 50)]) }
   let!(:chest_map) { Map.new(name: "Chest Map",
@@ -356,7 +356,7 @@ RSpec.describe Player do
       end
       # Newb should die and go to respawn location.
       expect(newb.gold).to eq 25
-      expect(newb.location.coords).to eq C[1, 2]
+      expect(newb.location.coords).to eq C[2, 1]
     end
 
     it "should allow the stronger player to win as the attacker" do
@@ -365,7 +365,7 @@ RSpec.describe Player do
       end
       # Weaker Player should die and go to respawn location.
       expect(newb.gold).to eq 25
-      expect(newb.location.coords).to eq C[1, 2]
+      expect(newb.location.coords).to eq C[2, 1]
       # Stronger Player should get weaker Players gold
       expect(dude.gold).to eq (35)
     end
@@ -376,7 +376,7 @@ RSpec.describe Player do
       end
       # Weaker Player should die and go to respawn location.
       expect(newb.gold).to eq 25
-      expect(newb.location.coords).to eq C[1, 2]
+      expect(newb.location.coords).to eq C[2, 1]
       # Stronger Player should get weaker Players gold
       expect(dude.gold).to eq (35)
     end
@@ -385,11 +385,11 @@ RSpec.describe Player do
 
   context "die" do
     it "moves the player back to the map's regen location" do
-      newb.move_down
-      expect(newb.location.coords).to eq C[2, 1]
+      newb.move_left
+      expect(newb.location.coords).to eq C[1, 0]
       newb.die
       expect(newb.location.map).to eq map
-      expect(newb.location.coords).to eq C[1, 2]
+      expect(newb.location.coords).to eq C[2, 1]
     end
 
     it "recovers the player's HP to max" do

--- a/spec/goby/entity/player_spec.rb
+++ b/spec/goby/entity/player_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe Player do
   let!(:slime) { Monster.new(battle_commands: [Attack.new(success_rate: 0)],
                              gold: 5000, treasures: [C[Item.new, 1]]) }
   let!(:newb) { Player.new(battle_commands: [Attack.new(success_rate: 0)],
-                           gold: 50, location: Location.new(map, center)) }
+                           gold: 50, location: Location.new(map, center),
+                           respawn_location: Location.new(map, C[1, 2])) }
   let!(:dragon) { Monster.new(stats: {attack: 50, agility: 10000},
                               battle_commands: [Attack.new(strength: 50)]) }
   let!(:chest_map) { Map.new(name: "Chest Map",
@@ -350,7 +351,7 @@ RSpec.describe Player do
       end
       # Newb should die and go to respawn location.
       expect(newb.gold).to eq 25
-      expect(newb.location.coords).to eq C[1, 1]
+      expect(newb.location.coords).to eq C[1, 2]
     end
 
     it "should allow the stronger player to win as the attacker" do
@@ -359,7 +360,7 @@ RSpec.describe Player do
       end
       # Weaker Player should die and go to respawn location.
       expect(newb.gold).to eq 25
-      expect(newb.location.coords).to eq C[1, 1]
+      expect(newb.location.coords).to eq C[1, 2]
       # Stronger Player should get weaker Players gold
       expect(dude.gold).to eq (35)
     end
@@ -370,7 +371,7 @@ RSpec.describe Player do
       end
       # Weaker Player should die and go to respawn location.
       expect(newb.gold).to eq 25
-      expect(newb.location.coords).to eq C[1, 1]
+      expect(newb.location.coords).to eq C[1, 2]
       # Stronger Player should get weaker Players gold
       expect(dude.gold).to eq (35)
     end
@@ -379,16 +380,17 @@ RSpec.describe Player do
 
   context "die" do
     it "moves the player back to the map's regen location" do
-      dude.move_down
-      expect(dude.location.coords).to eq C[2, 1]
-      dude.die
-      expect(dude.location.coords).to eq map.regen_coords
+      newb.move_down
+      expect(newb.location.coords).to eq C[2, 1]
+      newb.die
+      expect(newb.location.map).to eq map
+      expect(newb.location.coords).to eq C[1, 2]
     end
 
     it "recovers the player's HP to max" do
-      dude.set_stats(hp: 0)
-      dude.die
-      expect(dude.stats[:hp]).to eq dude.stats[:max_hp]
+      newb.set_stats(hp: 0)
+      newb.die
+      expect(newb.stats[:hp]).to eq newb.stats[:max_hp]
     end
   end
 

--- a/spec/goby/map/map_spec.rb
+++ b/spec/goby/map/map_spec.rb
@@ -3,22 +3,19 @@ require 'goby'
 RSpec.describe Map do
 
   let(:lake) { Map.new(name: "Lake",
-                    tiles: [ [ Tile.new, Tile.new(passable: false) ] ],
-                    regen_coords: C[0,1]) }
+                    tiles: [ [ Tile.new, Tile.new(passable: false) ] ] ) }
 
   context "constructor" do
     it "has the correct default parameters" do
       map = Map.new
       expect(map.name).to eq "Map"
       expect(map.tiles[0][0].passable).to be true
-      expect(map.regen_coords).to eq C[0,0]
     end
 
     it "correctly assigns custom parameters" do
       expect(lake.name).to eq "Lake"
       expect(lake.tiles[0][0].passable).to be true
       expect(lake.tiles[0][1].passable).to be false
-      expect(lake.regen_coords).to eq C[0,1]
     end
   end
 

--- a/spec/goby/world_command_spec.rb
+++ b/spec/goby/world_command_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe do
                               Tile.new(events: [NPC.new]),
                               Tile.new(events: [Event.new(visible: false)]) ],
                             [ Tile.new(events: [Shop.new, NPC.new]),
-                              Tile.new(events: [Event.new(visible: false), Shop.new, NPC.new]) ] ],
-                      regen_coords: C[0,0]) }
+                              Tile.new(events: [Event.new(visible: false), Shop.new, NPC.new]) ] ] ) }
 
   let!(:player) { Player.new(stats: { max_hp: 10, hp: 3 },
                          inventory: [ C[Food.new(name: "Banana", recovers: 5), 1],


### PR DESCRIPTION
The `Map` variable `regen_coords` has been removed in favor of a `Player` variable named `respawn_location`. Originally, each `Map` would provide the (y,x) coordinates at which one would respawn on that `Map`. However, it makes more sense for the `Player` to have a more global respawn point that can possibly change throughout the game. For instance, if the `Player` dies in a cave, it might make sense to respawn somewhere in the previous city.

This is a feature I've long had in the back of my head so please enjoy!
