### PR TITLE
fixed broken require in example

### DIFF
--- a/res/scaffold/simple/main.rb
+++ b/res/scaffold/simple/main.rb
@@ -2,7 +2,7 @@ require 'goby'
 
 include Goby
 
-require_relative 'map/farm.rb'
+require_relative 'farm.rb'
 
 # Set this to true in order to use BGM.
 Music::set_playback(false)


### PR DESCRIPTION
the line `require_relative 'map/farm.rb'` was an incorrect path, causing an error