### PR TITLE
Add detection of project folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Goby [![Build Status](https://travis-ci.org/nskins/goby.png)](https://travis-ci.org/nskins/goby) [![Coverage Status](https://coveralls.io/repos/github/nskins/goby/badge.svg?branch=master)](https://coveralls.io/github/nskins/goby?branch=master)
 
-Goby is a Ruby framework for creating [text](https://en.wikipedia.org/wiki/Text-based_game) [RPGs](https://en.wikipedia.org/wiki/Role-playing_game). Goby comes with out-of-the-box support for 2D map development, background music, PvP/PvM battles, customizable items & events, stats, equipment, and so much more. With thorough testing and documentation, it's even easy to expand upon the framework for special, unique features. If you are looking to create the next classic command-line RPG, then look no further!
+Goby is a Ruby framework for creating [CLI-based](https://en.wikipedia.org/wiki/Command-line_interface) [role-playing games](https://en.wikipedia.org/wiki/Role-playing_video_game). Goby comes with out-of-the-box support for 2D map development, background music, monster battles, customizable items & map events, stats, equipment, and so much more. With thorough testing and documentation, it's even easy to expand upon the framework for special, unique features. If you are looking to create the next classic command-line RPG, then look no further!
 
-Goby will always be free and open source software. If you have any questions, please contact the owner at nskins@umich.edu. He will be happy to assist you.
+Goby will always be free and open source software. If you have any questions, please contact nskins@umich.edu.
 
 ## Getting Started
 

--- a/lib/goby/scaffold.rb
+++ b/lib/goby/scaffold.rb
@@ -7,15 +7,12 @@ module Goby
     #
     # @param [String] project the project name.
     def self.simple(project)
-
-      # TODO: detect existence of project folder.
-
       # Make the directory structure.
-      Dir.mkdir project
+      Dir.mkdir project unless Dir.exist? project
       dirs = [ '', 'battle', 'entity',
                'event', 'item', 'map' ]
       dirs.each do |dir|
-        Dir.mkdir "#{project}/src/#{dir}"
+        Dir.mkdir "#{project}/src/#{dir}" unless Dir.exist? "#{project}/src/#{dir}"
       end
 
       # Create the source files.


### PR DESCRIPTION
Hello there. I had been exploring the project when I came across an issue.

If you run commands in the following sequence you will get:

```
$: bin/goby
$: rspec
```

```
Failures:

  1) Goby::Scaffold simple should create the appropriate directories & files
     Failure/Error: Dir.mkdir project

     Errno::EEXIST:
       File exists @ dir_s_mkdir - goby-project
     # ./lib/goby/scaffold.rb:14:in `mkdir'
     # ./lib/goby/scaffold.rb:14:in `simple'
     # ./spec/goby/scaffold_spec.rb:10:in `block (3 levels) in <top (required)>'

Finished in 0.19554 seconds (files took 0.34735 seconds to load)
308 examples, 1 failure
```

After investigating what was that I found a `TODO` tag in a file. 
So I think a bit of clearance will not harm 😃