### PR TITLE
153/Remove Travis CI References

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Goby Test Suite
+name: Tests
 
 on: [push, pull_request]
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,3 @@ gem 'coveralls', require: false
 
 # Specify your gem's dependencies in goby.gemspec
 gem 'rspec-mocks'
-
-# Required for Travis CI.
-group :test do
-  gem 'rake'
-end

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Goby [![Build Status](https://travis-ci.org/nskins/goby.png)](https://travis-ci.org/nskins/goby) [![Coverage Status](https://coveralls.io/repos/github/nskins/goby/badge.svg?branch=master)](https://coveralls.io/github/nskins/goby?branch=master)
+# Goby [![Coverage Status](https://coveralls.io/repos/github/nskins/goby/badge.svg?branch=master)](https://coveralls.io/github/nskins/goby?branch=master)
 
 Goby is a Ruby framework for creating [CLI-based](https://en.wikipedia.org/wiki/Command-line_interface) [role-playing games](https://en.wikipedia.org/wiki/Role-playing_video_game). Goby comes with out-of-the-box support for 2D map development, background music, monster battles, customizable items & map events, stats, equipment, and so much more. With thorough testing and documentation, it's even easy to expand upon the framework for special, unique features. If you are looking to create the next classic command-line RPG, then look no further!
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Goby [![Coverage Status](https://coveralls.io/repos/github/nskins/goby/badge.svg?branch=master)](https://coveralls.io/github/nskins/goby?branch=master)
+# Goby ![Tests](https://github.com/nskins/goby/workflows/Tests/badge.svg) [![Coverage Status](https://coveralls.io/repos/github/nskins/goby/badge.svg?branch=master)](https://coveralls.io/github/nskins/goby?branch=master)
 
 Goby is a Ruby framework for creating [CLI-based](https://en.wikipedia.org/wiki/Command-line_interface) [role-playing games](https://en.wikipedia.org/wiki/Role-playing_video_game). Goby comes with out-of-the-box support for 2D map development, background music, monster battles, customizable items & map events, stats, equipment, and so much more. With thorough testing and documentation, it's even easy to expand upon the framework for special, unique features. If you are looking to create the next classic command-line RPG, then look no further!
 


### PR DESCRIPTION
(Resolves #153) I removed the `rake` dependency required for Travis CI (it's still a dependency in `goby.gemspec` but Travis CI needed it in the `Gemfile` for some reason...). I also replaced the Travis CI build badge with a GitHub Actions build badge.