### PR TITLE
CLI Commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-
-# Created by https://www.gitignore.io/api/ruby
-
-### Ruby ###
 *.gem
 *.rbc
 /.config
@@ -46,15 +42,12 @@ build-iPhoneSimulator/
 
 # for a library or gem, you might want to ignore these files since the code is
 # intended to run in multiple environments; otherwise, check them in:
-Gemfile.lock
-.ruby-version
-.ruby-gemset
+# Gemfile.lock
+# .ruby-version
+# .ruby-gemset
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
 
-todo.txt
+# this is the save file
 player.yaml
-
-#Ignore RubyMine/IntelliJ project files
-/.idea/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,56 @@
+PATH
+  remote: .
+  specs:
+    goby (0.2.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    coveralls (0.8.23)
+      json (>= 1.8, < 3)
+      simplecov (~> 0.16.1)
+      term-ansicolor (~> 1.3)
+      thor (>= 0.19.4, < 2.0)
+      tins (~> 1.6)
+    diff-lcs (1.5.0)
+    docile (1.4.0)
+    json (2.6.1)
+    rake (13.0.6)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.2)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.3)
+    simplecov (0.16.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
+    sync (0.5.0)
+    term-ansicolor (1.7.1)
+      tins (~> 1.0)
+    thor (1.2.1)
+    tins (1.31.0)
+      sync
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 1.16)
+  coveralls
+  goby!
+  rake
+  rspec (~> 3.5)
+  rspec-mocks
+
+BUNDLED WITH
+   1.17.3

--- a/exe/goby
+++ b/exe/goby
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
 
 require 'goby'
-Goby::Scaffold::simple "goby-project"
+# Goby::Scaffold::simple "goby-project"
+Goby::GobyCLI::read_cli_args ARGV # ARGV is an array of strings that hold the arguments passed into the CLI

--- a/exe/goby
+++ b/exe/goby
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
 
 require 'goby'
-# Goby::Scaffold::simple "goby-project"
 Goby::GobyCLI::read_cli_args ARGV # ARGV is an array of strings that hold the arguments passed into the CLI

--- a/lib/goby/scaffold.rb
+++ b/lib/goby/scaffold.rb
@@ -6,16 +6,20 @@ module Goby
     # Simple starter project w/o testing.
     #
     # @param [String] project the project name.
-    def self.simple(project)
+    # @param [Boolean] boolean for deciding whether to init project on current or in a new directory
+    def self.simple
 
       # TODO: detect existence of project folder.
-
+      if File.exists? "src"
+        puts "A src directory already exists, please create a new folder!"
+        return
+      end
+      
       # Make the directory structure.
-      Dir.mkdir project
       dirs = [ '', 'battle', 'entity',
                'event', 'item', 'map' ]
       dirs.each do |dir|
-        Dir.mkdir "#{project}/src/#{dir}"
+        Dir.mkdir "src/#{dir}"
       end
 
       # Create the source files.
@@ -24,7 +28,7 @@ module Goby
                 'src/main.rb': 'main.rb',
                 'src/map/farm.rb': 'farm.rb' }
       files.each do |dest, source|
-        File.open("#{project}/#{dest.to_s}", 'w') do |w|
+        File.open("#{dest.to_s}", 'w') do |w|
           w.write(File.read "#{gem_location}/res/scaffold/simple/#{source}")
         end
       end

--- a/lib/goby/util.rb
+++ b/lib/goby/util.rb
@@ -112,4 +112,8 @@ module Goby
     end
   end
 
+  # Reads the ARGV
+  def read_cli_args(cli_arguments)
+  end
+
 end

--- a/lib/goby/util.rb
+++ b/lib/goby/util.rb
@@ -134,7 +134,7 @@ For more information, visit https://github.com/nskins/goby}
         when "init"
           puts "Executing init command..."
         when "--version", "--ver", "--v"
-          puts "Using goby v#{goby_ver}"
+          puts "goby v#{goby_ver}"
         else
           puts @@DEFAULT_HELP_MESSAGE
       end

--- a/lib/goby/util.rb
+++ b/lib/goby/util.rb
@@ -112,8 +112,34 @@ module Goby
     end
   end
 
-  # Reads the ARGV
-  def read_cli_args(cli_arguments)
+  # Class for running commands based on CLI input
+  class GobyCLI
+    # Default message to be shown if user inputs no arguments in OR user inputs invalid argument
+    # (I realise the spacing is messed up on the editor but it was the only way i found to make it look good on the console output)
+      @@DEFAULT_HELP_MESSAGE =  
+    %{Usage: goby <command>
+All available goby commands:
+  init             Initialize a new goby project in the current working directory
+  --version        Show the current version of goby
+          
+For more information, visit https://github.com/nskins/goby}
+
+    # Reads the ARGV and runs the given commands
+    # @param String[] (Array of strings)
+    def self.read_cli_args(cli_arguments)
+      user_input = cli_arguments[0] # Gets first arg. Eg: "goby init" would set USER_INPUT to "init"
+      goby_ver = Gem.loaded_specs["goby"].version
+
+      case user_input
+        when "init"
+          puts "Executing init command..."
+        when "--version", "--ver", "--v"
+          puts "Using goby v#{goby_ver}"
+        else
+          puts @@DEFAULT_HELP_MESSAGE
+      end
+
+    end
   end
 
 end

--- a/lib/goby/util.rb
+++ b/lib/goby/util.rb
@@ -119,8 +119,8 @@ module Goby
       @@DEFAULT_HELP_MESSAGE =  
     %{Usage: goby <command>
 All available goby commands:
-  init             Initialize a new goby project in the current working directory
-  --version        Show the current version of goby
+  init                 Initialize a new goby project in the current working directory
+  --version            Show the current version of goby
           
 For more information, visit https://github.com/nskins/goby}
 
@@ -128,17 +128,16 @@ For more information, visit https://github.com/nskins/goby}
     # @param String[] (Array of strings)
     def self.read_cli_args(cli_arguments)
       user_input = cli_arguments[0] # Gets first arg. Eg: "goby init" would set USER_INPUT to "init"
-      goby_ver = Gem.loaded_specs["goby"].version
+      goby_ver = Gem.loaded_specs["goby"].version # Gets the goby version stated in the gemspec
 
       case user_input
         when "init"
-          puts "Executing init command..."
+          Goby::Scaffold::simple
         when "--version", "--ver", "--v"
           puts "goby v#{goby_ver}"
         else
           puts @@DEFAULT_HELP_MESSAGE
       end
-
     end
   end
 

--- a/spec/goby/scaffold_spec.rb
+++ b/spec/goby/scaffold_spec.rb
@@ -4,26 +4,23 @@ require 'fileutils'
 RSpec.describe Scaffold do
 
   context "simple" do
-    it "should create the appropriate directories & files" do
+    it "should create the appropriate directories & files in the current directory" do
 
-      project = "goby-project"
-      Scaffold::simple project
+      Scaffold::simple
 
       # Ensure all of the directories exist.
-      expect(Dir.exists? "#{project}").to be true
       [ '', 'battle', 'entity',
       'event', 'item', 'map' ].each do |dir|
-        expect(Dir.exist? "#{project}/src/#{dir}").to be true
+        expect(Dir.exist? "src/#{dir}").to be true
       end
 
       # Ensure all of the files exist.
       [ '.gitignore', 'src/main.rb', 'src/map/farm.rb' ].each do |file|
-        expect(File.exist? "#{project}/#{file}").to be true
+        expect(File.exist? "#{file}").to be true
       end
 
       # Clean up the scaffolding.
-      FileUtils.remove_dir project
-
+      FileUtils.remove_dir "src"
     end
   end
 


### PR DESCRIPTION
Addressing #156 and #157 , this PR adds CLI commands.

Additions and changes:
- Creates new class for handling arguments passed into the goby executable
- Adds a new command "init" for creating project in the current directory
- Rewrites the Scaffold::Simple method to fit the requested functionality in #157
- Adds a "--version" flag for printing current goby version to the console (Currently has two aliases: --ver and --v)

RSpec passes all tests, and the new command functionalities fit the listed issue expectations.